### PR TITLE
Compare latest on main with pr when doing changes

### DIFF
--- a/.github/workflows/reusable.changes.yml
+++ b/.github/workflows/reusable.changes.yml
@@ -35,4 +35,3 @@ jobs:
         uses: tj-actions/changed-files@v17.3
         with: 
           files: ${{ inputs.files }}
-          since_last_remote_commit: 'true'


### PR DESCRIPTION
It should fix the problem of having consecutive commits comparison in PRs instead of main vs branch