### PR TITLE
Avoids identities duplication when recreated in kc

### DIFF
--- a/helm/configs/backend/login-callbacks.js
+++ b/helm/configs/backend/login-callbacks.js
@@ -2,7 +2,12 @@
 
 exports.accessGroupsToProfile =
   function (req, done) {
-    return function (err, user, identity, token) {
+    return async function (err, user, identity, token) {
+      await user.identities.destroyAll({and: [
+        {provider: identity.provider}, 
+        {id: {neq: identity.id}},
+        {userId: user.id}
+      ]});
       identity.updateAttributes({ 
         "profile": {
           accessGroups: identity.profile._json.pgroups,


### PR DESCRIPTION
When user is recreated in KC, the backend sees a new externalId, which causes a new identity to be created, which does not  update old attributes