### PR TITLE
Update job test config file

### DIFF
--- a/dev/config/test_backend_next/jobconfig.json
+++ b/dev/config/test_backend_next/jobconfig.json
@@ -1,87 +1,107 @@
 {
   "configVersion": "v1.0 2024-03-01 6f3f38",
   "jobs": [
-  {
-    "jobType": "all_access",
-    "configVersion": "v1.0 2024-03-01 6f3f38",
-    "create": {
-      "auth": "#all",
-      "actions": [
-        {
-          "actionType": "log"
-        },
-        {
-          "actionType": "url",
-          "url": "http://localhost:3000/api/v3/health?jobid={{id}}",
-          "headers": {
-            "accept": "application/json"
+    {
+      "jobType": "all_access",
+      "create": {
+        "auth": "#all",
+        "actions": [
+          {
+            "actionType": "log"
+          },
+          {
+            "actionType": "url",
+            "url": "http://localhost:3000/api/v3/health?jobid={{id}}",
+            "headers": {
+              "accept": "application/json"
+            }
           }
-        }
-      ]
-    },
-    "statusUpdate": {
-      "auth": "#all"
-    }
- },
- {
-    "jobType": "public_access",
-    "configVersion": "v1.0 2024-03-01 6f3f31",
-    "create": {
-      "auth": "#datasetPublic"
-    },
-    "statusUpdate": {
-      "auth": "#all"
-    }
+        ]
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
   },
   {
-    "jobType": "authenticated_access",
-    "configVersion": "v1.0 2024-03-01 6f3f32",
-    "create": {
-      "auth": "#authenticated"
+      "jobType": "public_access",
+      "create": {
+        "auth": "#datasetPublic"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
     },
-    "statusUpdate": {
-      "auth": "#all"
-    }
-  },
-  {
-    "jobType": "dataset_access",
-    "configVersion": "v1.0 2024-03-01 6f3f33",
-    "create": {
-      "auth": "#datasetAccess"
+    {
+      "jobType": "authenticated_access",
+      "create": {
+        "auth": "#authenticated"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
     },
-    "statusUpdate": {
-      "auth": "#jobOwnerGroup"
-    }
-  },
-  {
-    "jobType": "owner_access",
-    "configVersion": "v1.0 2024-03-01 6f3f34",
-    "create": {
-      "auth": "#datasetOwner"
+    {
+      "jobType": "dataset_access",
+      "create": {
+        "auth": "#datasetAccess"
+      },
+      "statusUpdate": {
+        "auth": "#jobOwnerGroup"
+      }
     },
-    "statusUpdate": {
-      "auth": "#jobOwnerUser"
-    }
-  },
-  {
-    "jobType": "user_access",
-    "configVersion": "v1.0 2024-03-01 6f3f35",
-    "create": {
-      "auth": "user5.1"
+    {
+      "jobType": "owner_access",
+      "create": {
+        "auth": "#datasetOwner"
+      },
+      "statusUpdate": {
+        "auth": "#jobOwnerUser"
+      }
     },
-    "statusUpdate": {
-      "auth": "user5.1"
-    }
-  },
-  {
-    "jobType": "group_access",
-    "configVersion": "v1.0 2024-03-01 6f3f36",
-    "create": {
-      "auth": "@group5"
+    {
+      "jobType": "user_access",
+      "create": {
+        "auth": "user5.1"
+      },
+      "statusUpdate": {
+        "auth": "user5.1"
+      }
     },
-    "statusUpdate": {
-      "auth": "@group5"
+    {
+      "jobType": "group_access",
+      "create": {
+        "auth": "@group5"
+      },
+      "statusUpdate": {
+        "auth": "@group5"
+      }
+    },
+    {
+      "jobType": "archive",
+      "create": {
+        "auth": "#all"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
+    },
+    {
+      "jobType": "retrieve",
+      "create": {
+        "auth": "#all"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
+    },
+    {
+      "jobType": "public",
+      "create": {
+        "auth": "#all"
+      },
+      "statusUpdate": {
+        "auth": "#all"
+      }
     }
-  }
   ]
 }


### PR DESCRIPTION
1. Remove `configVersion` from inside each job and keep only one `configVersion` at the top of the file.
2. Add configuration for `archive`, `retrieve` and `public` jobTypes, to accommodate the new test functions that are checking whether the `jobtype` matches the `datasetLifecycle.state` of the requested datasets.