### PR TITLE
Config and submodule update for landing page status message banner

### DIFF
--- a/helm/configs/landing-page-server/development/environment.ts
+++ b/helm/configs/landing-page-server/development/environment.ts
@@ -17,4 +17,6 @@ export const environment = {
       title: "Please enter your email address where you will receive the download procedure",
       confirmMessage: "Are you sure you want to continue?"
   },
-  };
+  statusMessage: "URL retrieve is currently down. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
+  statusCode: "WARN",
+};

--- a/helm/configs/landing-page-server/production/environment.ts
+++ b/helm/configs/landing-page-server/production/environment.ts
@@ -17,4 +17,6 @@ export const environment = {
       title: "Please enter your email address where you will receive the download procedure",
       confirmMessage: "Are you sure you want to continue?"
     },
-  };
+  statusMessage: "URL retrieve is currently down. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
+  statusCode: "WARN",
+};


### PR DESCRIPTION
This PR contains the landing-page-server feature that implements a status message banner. The appearance of banner is configurable based on statusCode = "WARN" | "INFO". If statusCode is "NONE" or not present, no banner is shown.

The landing-page-server commit was made on top of the deployed branch. We will also contribute this change to the latest branch soon.

Unit / e2e tests pass. Feature tested using scicatlive.