### PR TITLE
(landingpage) submodule update for help footer, and corresponding environment update

### DIFF
--- a/helm/configs/landing-page-server/development/environment.ts
+++ b/helm/configs/landing-page-server/development/environment.ts
@@ -17,6 +17,7 @@ export const environment = {
       title: "Please enter your email address where you will receive the download procedure",
       confirmMessage: "Are you sure you want to continue?"
   },
-  statusMessage: "URL retrieve is currently down. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
+  statusMessage: "Retrieving datasets > 5GB currently fails, due to technical issues at <a href='https://cscs.ch/' target=_blank>CSCS</a>. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
   statusCode: "WARN",
+  contactEmail: "scicat-help@lists.psi.ch",
 };

--- a/helm/configs/landing-page-server/production/environment.ts
+++ b/helm/configs/landing-page-server/production/environment.ts
@@ -19,4 +19,5 @@ export const environment = {
     },
   statusMessage: "Retrieving datasets > 5GB currently fails, due to technical issues at <a href='https://cscs.ch/' target=_blank>CSCS</a>. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
   statusCode: "WARN",
+  contactEmail: "scicat-help@lists.psi.ch",
 };

--- a/helm/configs/landing-page-server/qa/environment.ts
+++ b/helm/configs/landing-page-server/qa/environment.ts
@@ -17,5 +17,7 @@ export const environment = {
       title: "Please enter your email address where you will receive the download procedure",
       confirmMessage: "Are you sure you want to continue?"
     },
+    statusMessage: "Retrieving datasets > 5GB currently fails, due to technical issues at <a href='https://cscs.ch/' target=_blank>CSCS</a>. Please check <a href='https://scistatus.psi.ch/' target=_blank>https://scistatus.psi.ch/</a> for latest updates.",
+    statusCode: "WARN",
     contactEmail: "scicat-help@lists.psi.ch",
   };

--- a/helm/configs/landing-page-server/qa/environment.ts
+++ b/helm/configs/landing-page-server/qa/environment.ts
@@ -17,4 +17,5 @@ export const environment = {
       title: "Please enter your email address where you will receive the download procedure",
       confirmMessage: "Are you sure you want to continue?"
     },
+    contactEmail: "scicat-help@lists.psi.ch",
   };


### PR DESCRIPTION
PR in the main repo merged: https://github.com/SciCatProject/LandingPageServer/pull/396

We cherry-picked the above commit on top of the branch of landing-page-server that's currently deployed.