### PR TITLE
Use try except to avoid blocking execution

### DIFF
--- a/proposals/src/orchestrator.py
+++ b/proposals/src/orchestrator.py
@@ -55,7 +55,10 @@ class DuoSciCatOrchestrator(Orchestrator):
         log.info(f"============= Input proposal: {duo_proposal['proposal']}")
         policy = SciCatPolicyFromDuo(duo_proposal, accelerator)
         proposal = SciCatProposalFromDuo(duo_proposal, accelerator, self.duo_facility)
-        self._upsert_policy_and_proposal(policy, proposal)
+        try:
+            self._upsert_policy_and_proposal(policy, proposal)
+        except Exception as e:
+            log.error(e)
 
     def orchestrate(self):
         log.info(


### PR DESCRIPTION
During the refactor #300 , [this](https://github.com/paulscherrerinstitute/scicat-ci/pull/300/files#diff-c05cc80819ca022549dd3329943cbc600936207096a50583a8e0a7a784587180L37-L40) was left out. This caused the grafana alerts on saturday