### PR TITLE
Add PVC support to the generic_service templates

### DIFF
--- a/helm/charts/generic_service/templates/deployment.yaml
+++ b/helm/charts/generic_service/templates/deployment.yaml
@@ -6,6 +6,14 @@ metadata:
     {{- include "helm_chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "helm_chart.selectorLabels" . | nindent 6 }}
@@ -17,6 +25,14 @@ spec:
       labels:
         {{- include "helm_chart.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -29,6 +45,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ tpl .Values.image.repository $ }}:{{ tpl .Values.image.tag $ | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.image.tty }}
+          tty: {{ .Values.image.tty }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
@@ -51,6 +70,10 @@ spec:
           {{- end }}
           {{- with .Values.env }}
           env:
+            {{- tpl (toYaml .) $ | nindent 12 }}
+          {{- end }}
+          {{- with .Values.envFrom }}
+          envFrom:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- with .Values.volumeMounts }}

--- a/helm/charts/generic_service/templates/pvc.yaml
+++ b/helm/charts/generic_service/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- with .Values.storage -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .name | default (printf "%s-pvc" $.Release.Name) }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .accessModes | default "ReadWriteOnce" }}
+  resources:
+    requests:
+      storage: {{ .size }}
+{{- end -}}


### PR DESCRIPTION
These enhancements were used by the ingestor + globus-connect-personal images (https://github.com/paulscherrerinstitute/cloudsetup/pull/137).