### PR TITLE
Revert the frontend to psi-deployment-beta-release

### DIFF
--- a/.github/workflows/scicat-fe-next.yml
+++ b/.github/workflows/scicat-fe-next.yml
@@ -22,7 +22,7 @@ jobs:
     uses: ./.github/workflows/reusable.environment.yml
     with:
       commit: ${{ github.event.inputs.commit }}
-      submodule_commit: 21c172ae7b19f96f8a7272e85059d910e01dae33
+      submodule_commit: 85bad986332681233ad26336bddea8a5f1a16dbf
 
   check_changed:
     needs: set_env
@@ -35,7 +35,7 @@ jobs:
         helm/configs/frontend-next/${{ needs.set_env.outputs.environment }}/**
         frontend/**
       commit: ${{ needs.set_env.outputs.commit }}
-      submodule_commit: 21c172ae7b19f96f8a7272e85059d910e01dae33
+      submodule_commit: 85bad986332681233ad26336bddea8a5f1a16dbf
       submodule: frontend
 
   build_deploy_scicat_fe_next:
@@ -51,7 +51,7 @@ jobs:
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}
-      submodule_commit: 21c172ae7b19f96f8a7272e85059d910e01dae33
+      submodule_commit: 85bad986332681233ad26336bddea8a5f1a16dbf
       submodule: frontend
       helm_set_files: >-
         KEYCLOAK_ICON=helm/configs/frontend-next/keycloak_icon_256px.svg


### PR DESCRIPTION
This is an old branch (Nov 2025) that contains the depositor. I want to demo this today, after which this should be closed.

Do not merge.