### PR TITLE
feat: update s3-broker to v0.4 and mount AWS config and credentials

### DIFF
--- a/.github/workflows/s3-broker.yml
+++ b/.github/workflows/s3-broker.yml
@@ -39,7 +39,7 @@ jobs:
             helm/configs/${{ env.RELEASE_NAME }}/values.yaml
             helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml
           secrets: ${{ toJSON(secrets) }}
-          helm_set_files: >-
+          files: >-
             AWS_CONFIG=helm/configs/s3-broker/config
         env:
           KUBECONFIG_FILE: "${{ secrets.KUBECONFIG }}"

--- a/.github/workflows/s3-broker.yml
+++ b/.github/workflows/s3-broker.yml
@@ -39,6 +39,8 @@ jobs:
             helm/configs/${{ env.RELEASE_NAME }}/values.yaml
             helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml
           secrets: ${{ toJSON(secrets) }}
+          helm_set_files: >-
+            AWS_CONFIG=helm/configs/s3-broker/config
         env:
           KUBECONFIG_FILE: "${{ secrets.KUBECONFIG }}"
           RELEASE_NAME: s3-broker

--- a/helm/configs/s3-broker/config
+++ b/helm/configs/s3-broker/config
@@ -1,0 +1,3 @@
+[profile ceph]
+endpoint_url = https://rgw.cscs.ch
+region = us-east-1

--- a/helm/configs/s3-broker/values.yaml
+++ b/helm/configs/s3-broker/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/paulscherrerinstitute/scicat-s3-broker
-  tag: 0.3.1
+  tag: 0.4.0
   pullPolicy: Always
 
 service:
@@ -26,11 +26,16 @@ ingress:
         - "{{ .Values.host }}"
       secretName: "s3-broker-certificate"
 
+configMaps:
+  "{{ .Release.Name }}-cm":
+    config: "{{ .Values.AWS_CONFIG }}"
+
 secrets:
   "{{ .Release.Name }}-s":
     type: Opaque
     data:
       job_manager_password: "{{ .Values.secretsJson.JOB_MANAGER_PASSWORD }}"
+      credentials: "{{ .Values.secretsJson.S3_BROKER_CREDENTIALS }}"
 
 env:
   - name: SCICAT_URL
@@ -42,3 +47,19 @@ env:
       secretKeyRef:
         name: "{{ .Release.Name }}-s"
         key: job_manager_password
+
+volumes:
+  - name: secrets-volume
+    secret:
+      secretName: "{{ .Release.Name }}-s"
+  - name: config-volume
+    configMap:
+      name: "{{ .Release.Name }}-cm"
+
+volumeMounts:
+  - name: config-volume
+    mountPath: /env/config
+    subPath: config
+  - name: secrets-volume
+    mountPath: /env/credentials
+    subPath: credentials


### PR DESCRIPTION
s3-broker expects AWS shared credentials and config files to be present at [env/credentials](https://github.com/paulscherrerinstitute/scicat-s3-broker/blob/main/internal/s3/s3_handler.go#L25) and env/config relative to the server (which is started from `/` - [Dockerfile](https://github.com/paulscherrerinstitute/scicat-s3-broker/blob/main/Dockerfile#L22)).

Mounting the creds/config under /env. Updating s3-broker to v0.4.