### PR TITLE
Fix typo in EXPORTER_WHITELIST_IPS var

### DIFF
--- a/helm/configs/s3-broker/development/values.yaml
+++ b/helm/configs/s3-broker/development/values.yaml
@@ -6,4 +6,4 @@ scicat:
 
 ingress:
   annotations:
-    b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.EXPORTER_WHITELISTED_IPS }}"
+    b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.EXPORTER_WHITELIST_IPS }}"


### PR DESCRIPTION
Fixes a typo in #542 variable.