### PR TITLE
feat(s3-broker): add configuration for prod and qa deployments

### DIFF
--- a/.github/workflows/s3-broker.yml
+++ b/.github/workflows/s3-broker.yml
@@ -6,12 +6,16 @@ on:
     branches: [main]
     paths:
       - .github/workflows/s3-broker.yml
-      - helm/configs/s3-broker/**
+      - helm/configs/s3-broker/development/**
+      - helm/configs/s3-broker/values.yaml
+      - helm/configs/s3-broker/config
   push:
     branches: [main]
     paths:
       - .github/workflows/s3-broker.yml
-      - helm/configs/s3-broker/**
+      - helm/configs/s3-broker/qa/**
+      - helm/configs/s3-broker/values.yaml
+      - helm/configs/s3-broker/config
   release:
     types: [published]
 

--- a/.github/workflows/s3-broker.yml
+++ b/.github/workflows/s3-broker.yml
@@ -6,8 +6,14 @@ on:
     branches: [main]
     paths:
       - .github/workflows/s3-broker.yml
-      - helm/configs/s3-broker/values.yaml
-      - helm/configs/s3-broker/development/**
+      - helm/configs/s3-broker/**
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/s3-broker.yml
+      - helm/configs/s3-broker/**
+  release:
+    types: [published]
 
 jobs:
   set_env:

--- a/helm/configs/s3-broker/development/values.yaml
+++ b/helm/configs/s3-broker/development/values.yaml
@@ -1,7 +1,7 @@
 host: s3-broker.development.psi.ch
 
 scicat:
-  backend_url: http://backend-next.scicat-development/
+  backend_url: http://backend-next.scicat-development
   job_manager_username: jobManager
 
 ingress:

--- a/helm/configs/s3-broker/production/values.yaml
+++ b/helm/configs/s3-broker/production/values.yaml
@@ -1,0 +1,5 @@
+host: s3-broker.psi.ch
+
+scicat:
+  backend_url: http://backend-next.scicat-production
+  job_manager_username: jobManager

--- a/helm/configs/s3-broker/production/values.yaml
+++ b/helm/configs/s3-broker/production/values.yaml
@@ -3,3 +3,6 @@ host: s3-broker.psi.ch
 scicat:
   backend_url: http://backend-next.scicat-production
   job_manager_username: jobManager
+
+ingress:
+  enabled: false

--- a/helm/configs/s3-broker/qa/values.yaml
+++ b/helm/configs/s3-broker/qa/values.yaml
@@ -3,3 +3,6 @@ host: s3-broker.qa.psi.ch
 scicat:
   backend_url: http://backend-next.scicat-qa
   job_manager_username: jobManager
+
+ingress:
+  enabled: false

--- a/helm/configs/s3-broker/qa/values.yaml
+++ b/helm/configs/s3-broker/qa/values.yaml
@@ -1,0 +1,5 @@
+host: s3-broker.qa.psi.ch
+
+scicat:
+  backend_url: http://backend-next.scicat-qa
+  job_manager_username: jobManager

--- a/helm/configs/s3-broker/values.yaml
+++ b/helm/configs/s3-broker/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/paulscherrerinstitute/scicat-s3-broker
-  tag: 0.4.0
+  tag: 0.4.1
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
- Updated to tag v0.4.1 ([release](https://github.com/paulscherrerinstitute/scicat-s3-broker/releases/tag/v0.4.1)) which contains the public S3 URLs fix
- Added helm configs for qa and production
- Added workflow triggers `push` and `release` to s3-broker.yml