### PR TITLE
feat(scicat-exporter): add deployment config for qa and prod

### DIFF
--- a/.github/workflows/scicat-exporter.yml
+++ b/.github/workflows/scicat-exporter.yml
@@ -2,16 +2,20 @@ name: scicat-exporter
 
 on:
   workflow_dispatch:
-    paths:
-      - .github/workflows/scicat-exporter.yml
-      - helm/configs/scicat-exporter/values.yaml
-      - helm/configs/scicat-exporter/development/**
   pull_request:
     branches: [main]
     paths:
       - .github/workflows/scicat-exporter.yml
-      - helm/configs/scicat-exporter/values.yaml
       - helm/configs/scicat-exporter/development/**
+      - helm/configs/scicat-exporter/values.yaml
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/scicat-exporter.yml
+      - helm/configs/scicat-exporter/qa/**
+      - helm/configs/scicat-exporter/values.yaml
+  release:
+    types: [published]
 
 jobs:
   set_env:

--- a/helm/configs/landing-page-server/development/values.yaml
+++ b/helm/configs/landing-page-server/development/values.yaml
@@ -1,4 +1,5 @@
 host: oaipmh.development.psi.ch
+exporterHost: scicat-exporter.development.psi.ch
 
 ingresses:
   - enabled: true
@@ -8,7 +9,7 @@ ingresses:
       cert-manager.io/cluster-issuer: letsencrypt-prod
     hosts:
       - host: "{{ .Values.host }}"
-        paths: 
+        paths:
           - path: "/"
             pathType: Prefix
     tls:
@@ -23,7 +24,7 @@ ingresses:
       nginx.ingress.kubernetes.io/use-regex: "true"
       nginx.ingress.kubernetes.io/configuration-snippet: |
         if ($http_accept = "application/ld+json") {
-          return 302 "https://scicat-exporter.development.psi.ch/api/v1/zenodo/$1%2F$2/export";
+          return 302 "https://{{ .Values.exporterHost }}/api/v1/zenodo/$1%2F$2/export";
         }
     hosts:
       - host: "{{ .Values.host }}"

--- a/helm/configs/landing-page-server/production/values.yaml
+++ b/helm/configs/landing-page-server/production/values.yaml
@@ -1,4 +1,5 @@
 host: doi.psi.ch
+exporterHost: scicat-exporter.psi.ch
 
 secrets: 
   "{{ .Release.Name }}-s":

--- a/helm/configs/landing-page-server/qa/values.yaml
+++ b/helm/configs/landing-page-server/qa/values.yaml
@@ -1,1 +1,2 @@
 host: oaipmh.qa.psi.ch
+exporterHost: scicat-exporter.qa.psi.ch

--- a/helm/configs/landing-page-server/values.yaml
+++ b/helm/configs/landing-page-server/values.yaml
@@ -11,20 +11,35 @@ service:
   externalPort: 80
   internalPort: 80
 
-ingress:
-  enabled: true
-  annotations: 
-    kubernetes.io/ingress.class: nginx
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-  hosts:
-    - host: "{{ .Values.host }}"
-      paths: 
-        - path: "/"
-          pathType: Prefix
-  tls:
-    - hosts:
-      - "{{ .Values.host }}"
-      secretName: "scicat-oaipmh-certificate"
+ingresses:
+  - enabled: true
+    annotations:
+      kubernetes.io/ingress.class: nginx
+      cert-manager.io/cluster-issuer: letsencrypt-prod
+    hosts:
+      - host: "{{ .Values.host }}"
+        paths:
+          - path: "/"
+            pathType: Prefix
+    tls:
+      - hosts:
+        - "{{ .Values.host }}"
+        secretName: "scicat-oaipmh-certificate"
+  - enabled: true
+    name: renku-redirect
+    annotations:
+      b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.EXPORTER_WHITELIST_IPS }}"
+      kubernetes.io/ingress.class: nginx
+      nginx.ingress.kubernetes.io/use-regex: "true"
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        if ($http_accept = "application/ld+json") {
+          return 302 "https://{{ .Values.exporterHost }}/api/v1/zenodo/$1%2F$2/export";
+        }
+    hosts:
+      - host: "{{ .Values.host }}"
+        paths:
+          - path: /detail/([^/]+)/([^/]+)
+            pathType: ImplementationSpecific
 
 run:
   command: 

--- a/helm/configs/scicat-exporter/production/values.yaml
+++ b/helm/configs/scicat-exporter/production/values.yaml
@@ -1,0 +1,9 @@
+host: scicat-exporter.psi.ch
+
+env:
+  - name: QUARKUS_REST_CLIENT_SCICAT_URL
+    value: http://backend-next.scicat-production
+  - name: QUARKUS_REST_CLIENT_S3BROKER_URL
+    value: http://s3-broker.scicat-production
+  - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
+    value: 50M

--- a/helm/configs/scicat-exporter/production/values.yaml
+++ b/helm/configs/scicat-exporter/production/values.yaml
@@ -12,5 +12,5 @@ ingress:
   hosts:
     - host: "{{ .Values.host }}"
       paths:
-        - path: "/apiv/v1/zenodo"
+        - path: "/api/v1/zenodo"
           pathType: Prefix

--- a/helm/configs/scicat-exporter/production/values.yaml
+++ b/helm/configs/scicat-exporter/production/values.yaml
@@ -7,3 +7,10 @@ env:
     value: http://s3-broker.scicat-production
   - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
     value: 50M
+
+ingress:
+  hosts:
+    - host: "{{ .Values.host }}"
+      paths:
+        - path: "/apiv/v1/zenodo"
+          pathType: Exact

--- a/helm/configs/scicat-exporter/production/values.yaml
+++ b/helm/configs/scicat-exporter/production/values.yaml
@@ -13,4 +13,4 @@ ingress:
     - host: "{{ .Values.host }}"
       paths:
         - path: "/apiv/v1/zenodo"
-          pathType: Exact
+          pathType: Prefix

--- a/helm/configs/scicat-exporter/qa/values.yaml
+++ b/helm/configs/scicat-exporter/qa/values.yaml
@@ -7,3 +7,10 @@ env:
     value: http://s3-broker.scicat-qa
   - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
     value: 50M
+
+ingress:
+  hosts:
+    - host: "{{ .Values.host }}"
+      paths:
+        - path: "/apiv/v1/zenodo"
+          pathType: Exact

--- a/helm/configs/scicat-exporter/qa/values.yaml
+++ b/helm/configs/scicat-exporter/qa/values.yaml
@@ -12,5 +12,5 @@ ingress:
   hosts:
     - host: "{{ .Values.host }}"
       paths:
-        - path: "/apiv/v1/zenodo"
+        - path: "/api/v1/zenodo"
           pathType: Prefix

--- a/helm/configs/scicat-exporter/qa/values.yaml
+++ b/helm/configs/scicat-exporter/qa/values.yaml
@@ -1,0 +1,9 @@
+host: scicat-exporter.qa.psi.ch
+
+env:
+  - name: QUARKUS_REST_CLIENT_SCICAT_URL
+    value: http://backend-next.scicat-qa
+  - name: QUARKUS_REST_CLIENT_S3BROKER_URL
+    value: http://s3-broker.scicat-qa
+  - name: QUARKUS_HTTP_LIMITS_MAX_BODY_SIZE
+    value: 50M

--- a/helm/configs/scicat-exporter/qa/values.yaml
+++ b/helm/configs/scicat-exporter/qa/values.yaml
@@ -13,4 +13,4 @@ ingress:
     - host: "{{ .Values.host }}"
       paths:
         - path: "/apiv/v1/zenodo"
-          pathType: Exact
+          pathType: Prefix


### PR DESCRIPTION
- added qa/prod values to scicat-exporter, connecting s3-broker and scicat-backend in each stage
- added the `renku-redirect` ingress to the root config, and parametrized `exporterHost`