### PR TITLE
chore: update s3 broker docker tag to 0.5.1

### DIFF
--- a/helm/configs/s3-broker/values.yaml
+++ b/helm/configs/s3-broker/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/paulscherrerinstitute/scicat-s3-broker
-  tag: 0.4.1
+  tag: 0.5.1
   pullPolicy: Always
 
 service:


### PR DESCRIPTION
manually updating to 0.5.1 ([release notes](https://github.com/paulscherrerinstitute/scicat-s3-broker/releases/tag/v0.5.1)) that contain s3Uri change rather than waiting for renovate.