### PR TITLE
Add LBEM facility to globus

### DIFF
--- a/helm/configs/frontend-next/development/config.json
+++ b/helm/configs/frontend-next/development/config.json
@@ -216,8 +216,8 @@
             },
             {
                 "mailDomain": "epfl.ch",
-                "description": "DCI-Lausanne (EPFL/UNIL)",
-                "facilityBackend": "https://dci-ingestor.unil.ch/dev"
+                "description": "Laboratory of Biological Electron Microscopy (EPFL)",
+                "facilityBackend": "https://em-ingestor.epfl.ch/dev"
             },
             {
                 "mailDomain": "unibe.ch",
@@ -242,17 +242,17 @@
             {
                 "mailDomain": "ethz.ch",
                 "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
+                "facilityBackend": "https://localhost:8888/"
             },
             {
                 "mailDomain": "scopem.ethz.ch",
                 "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
+                "facilityBackend": "https://localhost:8888/"
             },
             {
                 "mailDomain": "id.ethz.ch",
                 "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
+                "facilityBackend": "https://localhost:8888/"
             }
         ]
     },

--- a/helm/configs/frontend-next/qa/config.json
+++ b/helm/configs/frontend-next/qa/config.json
@@ -205,56 +205,56 @@
     "ingestorComponent": {
         "ingestorEnabled": true,
         "ingestorAutodiscoveryOptions": [
-            {
-                "mailDomain": "psi.ch",
-                "description": "PSI Electron Microscopy Facility",
-                "facilityBackend": "https://emf-ingestor.psi.ch/qa"
-            },
-            {
-                "mailDomain": "unil.ch",
-                "description": "DCI-Lausanne (EPFL/UNIL)",
-                "facilityBackend": "https://dci-ingestor.unil.ch/qa"
-            },
-            {
-                "mailDomain": "epfl.ch",
-                "description": "DCI-Lausanne (EPFL/UNIL)",
-                "facilityBackend": "https://dci-ingestor.unil.ch/qa"
-            },
-            {
-                "mailDomain": "unibe.ch",
-                "description": "University of Bern",
-                "facilityBackend": "https://openem-ingestor.id.unibe.ch/qa"
-            },
-            {
-                "mailDomain": "unibas.ch",
-                "description": "University of Basel",
-                "facilityBackend": "https://openem.unibas.ch/qa"
-            },
-            {
-                "mailDomain": "unige.ch",
-                "description": "University of Geneva",
-                "facilityBackend": "https://openem-ingestor.unige.ch/qa"
-            },
-            {
-                "mailDomain": "empa.ch",
-                "description": "EMPA",
-                "facilityBackend": "https://openem-ingestor.empa.ch/qa"
-            },
-            {
-                "mailDomain": "ethz.ch",
-                "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
-            },
-            {
-                "mailDomain": "scopem.ethz.ch",
-                "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
-            },
-            {
-                "mailDomain": "id.ethz.ch",
-                "description": "ScopeM (ETHZ)",
-                "facilityBackend": "https://scopem-openem.ethz.ch/openem-ingestor"
-            }
+          {
+              "mailDomain": "psi.ch",
+              "description": "PSI Electron Microscopy Facility",
+              "facilityBackend": "https://emf-ingestor.psi.ch/qa"
+          },
+          {
+              "mailDomain": "unil.ch",
+              "description": "DCI-Lausanne (EPFL/UNIL)",
+              "facilityBackend": "https://dci-ingestor.unil.ch/qa"
+          },
+          {
+              "mailDomain": "epfl.ch",
+              "description": "Laboratory of Biological Electron Microscopy (EPFL)",
+              "facilityBackend": "https://em-ingestor.epfl.ch/qa"
+          },
+          {
+              "mailDomain": "unibe.ch",
+              "description": "University of Bern",
+              "facilityBackend": "https://openem-ingestor.id.unibe.ch/qa"
+          },
+          {
+              "mailDomain": "unibas.ch",
+              "description": "University of Basel",
+              "facilityBackend": "https://openem.unibas.ch/qa"
+          },
+          {
+              "mailDomain": "unige.ch",
+              "description": "University of Geneva",
+              "facilityBackend": "https://openem-ingestor.unige.ch/qa"
+          },
+          {
+              "mailDomain": "empa.ch",
+              "description": "EMPA",
+              "facilityBackend": "https://openem-ingestor.empa.ch/qa"
+          },
+          {
+            "mailDomain": "ethz.ch",
+            "description": "ScopeM (ETHZ)",
+            "facilityBackend": "https://localhost:8888/"
+          },
+          {
+              "mailDomain": "scopem.ethz.ch",
+              "description": "ScopeM (ETHZ)",
+              "facilityBackend": "https://localhost:8888/"
+          },
+          {
+              "mailDomain": "id.ethz.ch",
+              "description": "ScopeM (ETHZ)",
+              "facilityBackend": "https://localhost:8888/"
+          }
         ]
     },
     "mainMenu": {

--- a/helm/configs/globus-proxy/development/config.yaml
+++ b/helm/configs/globus-proxy/development/config.yaml
@@ -38,3 +38,6 @@ facilities:
   - <<: *openemFacility
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
+  - <<: *openemFacility
+    name: LBEM
+    collection: ed650f52-0235-4c40-a573-5f8de55841a6

--- a/helm/configs/globus-proxy/production/config.yaml
+++ b/helm/configs/globus-proxy/production/config.yaml
@@ -29,3 +29,6 @@ facilities:
   - <<: *openemFacility
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
+  - <<: *openemFacility
+    name: LBEM
+    collection: ed650f52-0235-4c40-a573-5f8de55841a6

--- a/helm/configs/globus-proxy/qa/config.yaml
+++ b/helm/configs/globus-proxy/qa/config.yaml
@@ -29,3 +29,6 @@ facilities:
   - <<: *openemFacility
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
+  - <<: *openemFacility
+    name: LBEM
+    collection: ed650f52-0235-4c40-a573-5f8de55841a6


### PR DESCRIPTION
Updates some configuration settings to add LBEM.

This can also be a trigger to redeploy globus-proxy to QA, which failed last time.