### PR TITLE
Remove leading slash from QA group names in globus-proxy

### DIFF
--- a/helm/configs/globus-proxy/qa/config.yaml
+++ b/helm/configs/globus-proxy/qa/config.yaml
@@ -4,7 +4,7 @@ port: 8080
 defaults:
   - &openemFacility
     direction: SRC
-    accessValue: "/{{.Name}}"
+    accessValue: "{{.Name}}"
 
 facilities:
   - name: PSI_QA


### PR DESCRIPTION
Another tiny config change that only effects QA.