### PR TITLE
feat: pass a chart version through the helm deploy workflow

### DIFF
--- a/.github/actions/deploy-helm/action.yml
+++ b/.github/actions/deploy-helm/action.yml
@@ -11,9 +11,13 @@ inputs:
     required: false
     type: string
     default: default
-  chart: 
+  chart:
     description: chart to deploy
     required: true
+    type: string
+  version:
+    description: chart version, for charts pulled from a registry
+    required: false
     type: string
   values: 
     description: values to inject from command line
@@ -40,7 +44,8 @@ runs:
         values=`echo ${{ inputs.value-files }} | tr -s ' ' ','`;
         set=`echo ${{ inputs.values }} | tr -s ' ' ','`;
         set_file=`echo ${{ inputs.files }} | tr -s ' ' ','`;
-        helm upgrade ${{ inputs.release }} ${{ inputs.chart }} \
+        version=""; if [ -n "${{ inputs.version }}" ]; then version="--version=${{ inputs.version }}"; fi;
+        helm upgrade ${{ inputs.release }} ${{ inputs.chart }} $version \
           --namespace ${{ inputs.namespace }} --create-namespace \
           --install --wait --atomic --values=$values --set=$set \
           --set-file=$set_file --set-json secretsJson='${{ inputs.secrets }}' &> /dev/null

--- a/.github/workflows/reusable.build-deploy.yml
+++ b/.github/workflows/reusable.build-deploy.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: helm/charts/generic_service
+      helm_chart_version:
+        description: chart version, for charts pulled from a registry
+        required: false
+        type: string
+        default: ""
       docker_build_files:
         required: false
         type: string
@@ -150,6 +155,7 @@ jobs:
         release: '${{ inputs.release_name }}'
         namespace: '${{ inputs.namespace_prefix }}${{ inputs.environment }}'
         chart: '${{ inputs.helm_chart }}'
+        version: '${{ inputs.helm_chart_version }}'
         values: >-
          ciRepository=${{ inputs.registry }}/${{ inputs.image_name }}
          ciTag=${{ inputs.tag }}


### PR DESCRIPTION
Adds an optional chart version input to the helm deploy action and threads it through `reusable.build-deploy.yml` as `helm_chart_version`, so a caller can pull a pinned chart from the dc-charts OCI registry. No service is switched here and nothing deploys, the shared files are in no change filter.

First step of the sequential dc-charts rewire. Services follow one per PR, starting with low-impact, per the review on #584  (moved off the fork to a branch on this repo).
