### PR TITLE
feat: deploy scicat-exporter from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-exporter.yml
+++ b/.github/workflows/scicat-exporter.yml
@@ -42,7 +42,8 @@ jobs:
         with:
           release: "${{ env.RELEASE_NAME }}"
           namespace: "${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}"
-          chart: helm/charts/generic_service
+          chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+          version: 1.0.0
           value-files: >-
             helm/configs/${{ env.RELEASE_NAME }}/values.yaml
             helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml

--- a/helm/configs/scicat-exporter/values.yaml
+++ b/helm/configs/scicat-exporter/values.yaml
@@ -32,3 +32,7 @@ ingress:
     - hosts:
         - "{{ .Values.host }}"
       secretName: "scicat-exporter-certificate"
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
First service of the sequential rollout to the published charts. Switches scicat-exporter from the vendored `helm/charts/generic_service` chart to `oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service`, pinned to 1.0.0.

The published chart is named `generic-service` while the vendored one is `generic-service-chart`. The chart name feeds the deployment selector, which is immutable on a live release. The values file therefore pins `nameOverride: generic-service-chart`, keeping the selector and all resource names identical. The only visible change is the deployment container name, so the upgrade causes one rolling restart.

Verification:
- rendered the exporter config against both charts, the diff shows only the `# Source` paths, the `helm.sh/chart` label, and the container name
- minikube rehearsal, install from the vendored chart then upgrade to the OCI package, the upgrade succeeds with the selector unchanged

The vendored charts stay in place until every service is switched.
