### PR TITLE
feat: deploy oaipmh from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-oaipmh.yml
+++ b/.github/workflows/scicat-oaipmh.yml
@@ -47,6 +47,8 @@ jobs:
       context: oaipmh/.
       image_name: ${{ github.repository }}/oaipmh
       release_name: oaipmh
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/oaipmh/values.yaml
+++ b/helm/configs/oaipmh/values.yaml
@@ -49,3 +49,7 @@ env:
     value: PSI
   - name: BASE_URL
     value: https://{{ .Values.host }}
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches oaipmh to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.
