### PR TITLE
feat: deploy the backend from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-be.yml
+++ b/.github/workflows/scicat-be.yml
@@ -51,6 +51,8 @@ jobs:
       context: backend/.
       image_name: ${{ github.repository }}/be
       release_name: backend
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/backend/values.yaml
+++ b/helm/configs/backend/values.yaml
@@ -129,3 +129,7 @@ probeChecks:
   periodSeconds: 20
   timeoutSeconds: 5
   failureThreshold: 5 
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches the backend to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart (including both ingresses, the secret, and the configmap) shows only the chart-name cosmetics, the selector is unchanged.
