### PR TITLE
feat: deploy the ingestor from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-ingestor.yml
+++ b/.github/workflows/scicat-ingestor.yml
@@ -41,7 +41,8 @@ jobs:
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'
-        chart: helm/charts/generic_service
+        chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+        version: 1.0.0
         value-files: >-
           helm/configs/${{ env.RELEASE_NAME }}/values.yaml
           helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml

--- a/helm/configs/ingestor/values.yaml
+++ b/helm/configs/ingestor/values.yaml
@@ -85,3 +85,7 @@ probeChecks:
 
 securityContext:
    runAsUser: 0
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches the ingestor to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.