### PR TITLE
feat: deploy pss from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-pss.yml
+++ b/.github/workflows/scicat-pss.yml
@@ -45,7 +45,8 @@ jobs:
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'
-        chart: helm/charts/generic_service
+        chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+        version: 1.0.0
         values: "db=${{ env.RELEASE_NAME }}-${{ env.ENVIRONMENT }}"
         value-files: helm/configs/${{ env.RELEASE_NAME }}/values.yaml
         secrets:  ${{ toJSON(secrets) }}

--- a/helm/configs/pss/values.yaml
+++ b/helm/configs/pss/values.yaml
@@ -30,3 +30,7 @@ secrets:
     type: Opaque
     data: 
       pss_mongodb_url: "{{ .Values.secretsJson.PSS_MONGODB_URL }}"
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches pss to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.