### PR TITLE
feat: deploy the landing page server from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-landing-page-server.yml
+++ b/.github/workflows/scicat-landing-page-server.yml
@@ -47,6 +47,8 @@ jobs:
       context: landing-page-server/.
       image_name: ${{ github.repository }}/landing-page-server
       release_name: landing-page-server
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/landing-page-server/values.yaml
+++ b/helm/configs/landing-page-server/values.yaml
@@ -68,3 +68,7 @@ volumeMounts:
   - name: config-volume
     mountPath: /usr/share/nginx/html/assets/favicon.ico.b64
     subPath: favicon.ico.b64
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches the landing page server to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart (both ingresses included) shows only the chart-name cosmetics, the selector is unchanged.