### PR TITLE
feat: deploy pan-ontologies-api from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-pan-ontologies-api.yml
+++ b/.github/workflows/scicat-pan-ontologies-api.yml
@@ -47,6 +47,8 @@ jobs:
       context: pan-ontologies-api/.
       image_name: ${{ github.repository }}/pan-ontologies-api
       release_name: pan-ontologies-api
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/pan-ontologies-api/values.yaml
+++ b/helm/configs/pan-ontologies-api/values.yaml
@@ -25,3 +25,7 @@ ingress:
     - hosts:
       - "{{ .Values.host }}"
       secretName: "scicat-ont-certificate"
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches pan-ontologies-api to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.