### PR TITLE
feat: deploy search-api from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-search-api.yml
+++ b/.github/workflows/scicat-search-api.yml
@@ -47,6 +47,8 @@ jobs:
       context: search-api/.
       image_name: ${{ github.repository }}/search-api
       release_name: search-api
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/search-api/values.yaml
+++ b/helm/configs/search-api/values.yaml
@@ -59,3 +59,7 @@ volumeMounts:
   - name: config-volume
     mountPath: /home/node/app/server/component-config.json
     subPath: component-config.json
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches search-api to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.