### PR TITLE
feat: deploy backend-next from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-be-next.yml
+++ b/.github/workflows/scicat-be-next.yml
@@ -51,6 +51,8 @@ jobs:
       context: scicat-backend-next/.
       image_name: ${{ github.repository }}/backend-next
       release_name: backend-next
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/backend-next/values.yaml
+++ b/helm/configs/backend-next/values.yaml
@@ -124,3 +124,7 @@ jobContainers:
         mountPath: /home/node/app/migrations/20260127161201-migrate-broken-legacy-history.js
         subPath: 20260127161201-migrate-broken-legacy-history.js
 
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches backend-next to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. This is the fullest consumer of the chart (CronJob, migrate Job, and RBAC via `jobContainers`). The render diff against the vendored chart shows only the chart-name cosmetics plus the migrate job's random name suffix, which changes on every render. The selector is unchanged.