### PR TITLE
feat: deploy frontend-next from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-fe-next.yml
+++ b/.github/workflows/scicat-fe-next.yml
@@ -48,6 +48,8 @@ jobs:
       context: frontend/.
       image_name: ${{ github.repository }}/fe-next
       release_name: frontend-next
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+      helm_chart_version: 1.0.0
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
       commit: ${{ needs.set_env.outputs.commit }}

--- a/helm/configs/frontend-next/values.yaml
+++ b/helm/configs/frontend-next/values.yaml
@@ -70,3 +70,7 @@ volumeMounts:
   - name: downloaddir
     mountPath: /usr/share/nginx/html/assets/images/site-logo.png
     subPath: site-logo.png
+
+# Keep the pre-rename chart name so selectors and resource names still match
+# releases installed from the vendored charts (Deployment selectors are immutable).
+nameOverride: generic-service-chart


### PR DESCRIPTION
Same recipe as #588. Switches frontend-next to the published `generic-service` chart pinned to 1.0.0, with the `nameOverride` bridge in the values file. The render diff against the vendored chart shows only the chart-name cosmetics, the selector is unchanged.