### PR TITLE
feat: deploy scicat-to-pss from the published dc-charts oci package

### DIFF
--- a/.github/workflows/scicat-to-pss.yml
+++ b/.github/workflows/scicat-to-pss.yml
@@ -43,7 +43,8 @@ jobs:
       release_name: scicat-to-pss
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
-      helm_chart: helm/charts/cron
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/cron
+      helm_chart_version: 1.0.0
       commit: ${{ needs.set_env.outputs.commit }}
     secrets:
       KUBECONFIG: ${{ secrets.KUBECONFIG }}

--- a/helm/configs/scicat-to-pss/values.yaml
+++ b/helm/configs/scicat-to-pss/values.yaml
@@ -10,3 +10,7 @@ env:
     value: "{{ .Values.scicatBaseUrl }}"
   - name: PSS_BASE_URL
     value: "{{ .Values.pssBaseUrl }}"
+
+# Keep the pre-rename chart name so resource names stay stable for the
+# release installed from the vendored cron-chart.
+nameOverride: cron-chart


### PR DESCRIPTION
First cron-chart consumer of the rollout. Switches scicat-to-pss to the published `cron` chart pinned to 1.0.0.

Unlike the deployment-based services (#588 and the follow-ups), a CronJob has no immutable selector. The `nameOverride: cron-chart` bridge is still applied so all resource names stay stable across the chart rename, and the values comment says so explicitly.

Verification: the render diff against the vendored chart shows only the `# Source` path and the `helm.sh/chart` label (the cron container is named after the release, so not even a container-name change). A minikube rehearsal installed the release from the vendored chart and upgraded it to the OCI package, the upgrade completed in place with the CronJob name unchanged.