### PR TITLE
feat: deploy materialised-view from the published dc-charts oci package

### DIFF
--- a/.github/workflows/materialised-view.yml
+++ b/.github/workflows/materialised-view.yml
@@ -40,7 +40,8 @@ jobs:
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'
-        chart: helm/charts/cron
+        chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/cron
+        version: 1.0.0
         value-files: >-
           helm/configs/${{ env.RELEASE_NAME }}/values.yaml
           helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml

--- a/helm/configs/materialised-view/values.yaml
+++ b/helm/configs/materialised-view/values.yaml
@@ -40,3 +40,7 @@ volumeMounts:
   - name: config-volume
     mountPath: /updateMatViews.js
     subPath: updateMatViews.js
+
+# Keep the pre-rename chart name so resource names stay stable for the
+# release installed from the vendored cron-chart.
+nameOverride: cron-chart


### PR DESCRIPTION
Same recipe as #602. Switches materialised-view to the published `cron` chart pinned to 1.0.0, with the `nameOverride` bridge keeping resource names stable. The render diff against the vendored chart (secret, configmap, and cronjob) shows only the chart-name cosmetics. The minikube install and upgrade rehearsal from #602 covers this chart pair.