### PR TITLE
feat: deploy proposals-sync from the published dc-charts oci package

### DIFF
--- a/.github/workflows/proposals-sync.yml
+++ b/.github/workflows/proposals-sync.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Helm template
         run: | 
-          helm template proposals --debug ../helm/charts/duo_facility_proposals --values=../helm/configs/proposals/values.yaml --values=../helm/configs/proposals/development/values.yaml > /dev/null
+          helm template proposals --debug oci://ghcr.io/paulscherrerinstitute/dc-charts/proposals-cronjob --version=0.1.1 --values=../helm/configs/proposals/values.yaml --values=../helm/configs/proposals/development/values.yaml > /dev/null
 
       - name: Build
         run: |
@@ -80,7 +80,8 @@ jobs:
       release_name: proposals
       tag: ${{ needs.set_env.outputs.tag }}
       environment: ${{ needs.set_env.outputs.environment }}
-      helm_chart: helm/charts/duo_facility_proposals
+      helm_chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/proposals-cronjob
+      helm_chart_version: 0.1.1
       commit: ${{ needs.set_env.outputs.commit }}
     secrets:
       KUBECONFIG: ${{ secrets.KUBECONFIG }}

--- a/helm/configs/proposals/values.yaml
+++ b/helm/configs/proposals/values.yaml
@@ -26,3 +26,7 @@ volumeMounts:
 
 cronjob:
   ttlSecondsAfterFinished: 691200 # 8 days (7+1 of buffer)
+
+# Keep the pre-rename chart name so resource names stay stable for the
+# release installed from the vendored duo_facility_proposals chart.
+nameOverride: proposals-cronjob-chart


### PR DESCRIPTION
Last service of the rollout. Switches proposals-sync to the published `proposals-cronjob` chart pinned to 0.1.1, with the `nameOverride` bridge in the values file. Two things differ from the earlier PRs. The `test_lint` job also helm-templates the chart at PR time, so that step now pulls the OCI package too. And this chart renders one CronJob per DUO facility with the chart name embedded in each name, so the bridge keeps those names stable.