### PR TITLE
chore: require an explicit helm_chart input

### DIFF
--- a/.github/workflows/reusable.build-deploy.yml
+++ b/.github/workflows/reusable.build-deploy.yml
@@ -30,9 +30,9 @@ on:
         type: string
         default: scicat-
       helm_chart:
-        required: false
+        description: chart reference, local path or OCI URL
+        required: true
         type: string
-        default: helm/charts/generic_service
       helm_chart_version:
         description: chart version, for charts pulled from a registry
         required: false


### PR DESCRIPTION
All scicat-ci and scilog-ci callers now pass an explicit chart reference and the vendored charts are gone, so the `helm/charts/generic_service` default no longer resolves in this repo.

Closes #601