### PR TITLE
chore: pin action refs ahead of the deploy refactor

### DIFF
--- a/.github/workflows/materialised-view.yml
+++ b/.github/workflows/materialised-view.yml
@@ -30,13 +30,13 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Open ssh tunnel
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with: 
         bastion_user: '${{ secrets.BASTION_USER }}'
         bastion_ssh_key: '${{ secrets.BASTION_SSH_KEY }}'
 
     - name: deploy
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'

--- a/.github/workflows/reusable.build-deploy.yml
+++ b/.github/workflows/reusable.build-deploy.yml
@@ -91,7 +91,7 @@ jobs:
         ref: ${{ inputs.commit }}
 
     - if: ${{ inputs.submodule_commit }}
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/checkout-submodule@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/checkout-submodule@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with: 
         submodule_commit: ${{ inputs.submodule_commit }}
         commit: ${{ inputs.commit }}
@@ -143,14 +143,14 @@ jobs:
         ref: ${{ inputs.commit }}
 
     - name: Open ssh tunnel
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with: 
         bastion_user: '${{ secrets.BASTION_USER }}'
         bastion_ssh_key: '${{ secrets.BASTION_SSH_KEY }}'
 
     - name: Deploy to k8s using helm
       id: helm-deploy
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         release: '${{ inputs.release_name }}'
         namespace: '${{ inputs.namespace_prefix }}${{ inputs.environment }}'

--- a/.github/workflows/reusable.changes.yml
+++ b/.github/workflows/reusable.changes.yml
@@ -53,7 +53,7 @@ jobs:
           git checkout $current_commit && git submodule update --recursive;
 
       - if: ${{ inputs.submodule_commit }}
-        uses: paulscherrerinstitute/scicat-ci/.github/actions/checkout-submodule@main
+        uses: paulscherrerinstitute/scicat-ci/.github/actions/checkout-submodule@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
         with:
           submodule_commit: ${{ inputs.submodule_commit }}
           commit: ${{ inputs.commit }}

--- a/.github/workflows/s3-broker.yml
+++ b/.github/workflows/s3-broker.yml
@@ -34,13 +34,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Open ssh tunnel
-        uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+        uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
         with:
           bastion_user: "${{ secrets.BASTION_USER }}"
           bastion_ssh_key: "${{ secrets.BASTION_SSH_KEY }}"
 
       - name: deploy
-        uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+        uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
         with:
           release: "${{ env.RELEASE_NAME }}"
           namespace: "${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}"

--- a/.github/workflows/scicat-exporter.yml
+++ b/.github/workflows/scicat-exporter.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Open ssh tunnel
-        uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+        uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
         with:
           bastion_user: "${{ secrets.BASTION_USER }}"
           bastion_ssh_key: "${{ secrets.BASTION_SSH_KEY }}"

--- a/.github/workflows/scicat-globus-proxy.yml
+++ b/.github/workflows/scicat-globus-proxy.yml
@@ -34,13 +34,13 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Open ssh tunnel
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         bastion_user: '${{ secrets.BASTION_USER }}'
         bastion_ssh_key: '${{ secrets.BASTION_SSH_KEY }}'
 
     - name: deploy
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'

--- a/.github/workflows/scicat-ingestor.yml
+++ b/.github/workflows/scicat-ingestor.yml
@@ -31,13 +31,13 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Open ssh tunnel
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         bastion_user: '${{ secrets.BASTION_USER }}'
         bastion_ssh_key: '${{ secrets.BASTION_SSH_KEY }}'
 
     - name: deploy
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'

--- a/.github/workflows/scicat-pss.yml
+++ b/.github/workflows/scicat-pss.yml
@@ -35,13 +35,13 @@ jobs:
       uses: actions/checkout@v7
 
     - name: Open ssh tunnel
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/open-ssh-tunnel@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with: 
         bastion_user: '${{ secrets.BASTION_USER }}'
         bastion_ssh_key: '${{ secrets.BASTION_SSH_KEY }}'
 
     - name: deploy 
-      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+      uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@b4da1ca8afb1aac8b95bff96f98e70ae1f83aa35
       with:
         release: '${{ env.RELEASE_NAME }}'
         namespace: '${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}'


### PR DESCRIPTION
Freezes the same-repo action refs at the current main sha, so the deploy refactor cannot shift legacy behavior underneath.