### PR TITLE
feat: deploy scicat-exporter through helmfile

### DIFF
--- a/.github/actions/deploy-helmfile/action.yml
+++ b/.github/actions/deploy-helmfile/action.yml
@@ -1,0 +1,64 @@
+name: deploy-helmfile
+description: "Deploy a component through its helmfile state"
+
+inputs:
+  file:
+    description: path to the component's helmfile state
+    required: true
+  environment:
+    description: helmfile environment to select
+    required: true
+  kubeconfig:
+    description: base64 kubeconfig for the target cluster
+    required: true
+  secrets:
+    description: JSON blob exposed to the helmfile state as .Values.secrets
+    required: false
+    default: ""
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install helmfile
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        curl -fsSL -o "$RUNNER_TEMP/helmfile.tar.gz" \
+          "https://github.com/helmfile/helmfile/releases/download/v${VERSION}/helmfile_${VERSION}_linux_amd64.tar.gz"
+        echo "${SHA256}  $RUNNER_TEMP/helmfile.tar.gz" | sha256sum -c --quiet
+        sudo tar xzf "$RUNNER_TEMP/helmfile.tar.gz" -C /usr/local/bin helmfile
+      env:
+        VERSION: 1.7.1
+        SHA256: d84a8e5ffdbfd66f1bfb4b11967b9d2981d8515c7d6e312ee0cd89b613c8b352
+
+    - name: Deploy
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        export KUBECONFIG="$RUNNER_TEMP/kubeconfig"
+        printf '%s' "$KUBECONFIG_FILE" | base64 -d > "$KUBECONFIG"
+
+        # Secrets travel in a file rather than through --state-values-set: the
+        # command line is readable from /proc, and that flag parses through
+        # helm's strvals, where a comma inside a value silently splits it.
+        state_values=()
+        if [ -n "$SECRETS" ]; then
+          umask 077
+          printf '{"secrets":%s}' "$SECRETS" > "$RUNNER_TEMP/state-values.yaml"
+          state_values=(--state-values-file "$RUNNER_TEMP/state-values.yaml")
+        fi
+
+        # helm dumps the fully rendered template on failure, credentials
+        # included, so its output stays hidden while secrets still reach it.
+        if ! helmfile --file "$FILE" --environment "$ENVIRONMENT" \
+             "${state_values[@]}" sync &> /dev/null; then
+          echo "::error::helmfile sync failed for $FILE (environment: $ENVIRONMENT)"
+          exit 1
+        fi
+      env:
+        FILE: ${{ inputs.file }}
+        ENVIRONMENT: ${{ inputs.environment }}
+        KUBECONFIG_FILE: ${{ inputs.kubeconfig }}
+        SECRETS: ${{ inputs.secrets }}

--- a/.github/workflows/scicat-exporter.yml
+++ b/.github/workflows/scicat-exporter.yml
@@ -6,12 +6,18 @@ on:
     branches: [main]
     paths:
       - .github/workflows/scicat-exporter.yml
+      - .github/actions/deploy-helmfile/**
+      - helm/helmfile-common.yaml
+      - helm/configs/scicat-exporter/helmfile.yaml.gotmpl
       - helm/configs/scicat-exporter/development/**
       - helm/configs/scicat-exporter/values.yaml
   push:
     branches: [main]
     paths:
       - .github/workflows/scicat-exporter.yml
+      - .github/actions/deploy-helmfile/**
+      - helm/helmfile-common.yaml
+      - helm/configs/scicat-exporter/helmfile.yaml.gotmpl
       - helm/configs/scicat-exporter/qa/**
       - helm/configs/scicat-exporter/values.yaml
   release:
@@ -38,18 +44,10 @@ jobs:
           bastion_ssh_key: "${{ secrets.BASTION_SSH_KEY }}"
 
       - name: deploy
-        uses: paulscherrerinstitute/scicat-ci/.github/actions/deploy-helm@main
+        uses: ./.github/actions/deploy-helmfile
         with:
-          release: "${{ env.RELEASE_NAME }}"
-          namespace: "${{ env.NAMESPACE_PREFIX }}${{ env.ENVIRONMENT }}"
-          chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
-          version: 1.0.0
-          value-files: >-
-            helm/configs/${{ env.RELEASE_NAME }}/values.yaml
-            helm/configs/${{ env.RELEASE_NAME }}/${{ env.ENVIRONMENT }}/values.yaml
-          secrets:  ${{ toJSON(secrets) }}
-        env:
-          KUBECONFIG_FILE: "${{ secrets.KUBECONFIG }}"
-          RELEASE_NAME: scicat-exporter
-          ENVIRONMENT: "${{ needs.set_env.outputs.environment }}"
-          NAMESPACE_PREFIX: scicat-
+          file: helm/configs/scicat-exporter/helmfile.yaml.gotmpl
+          environment: "${{ needs.set_env.outputs.environment }}"
+          kubeconfig: "${{ secrets.KUBECONFIG }}"
+          # toJSON quotes and escapes the value, secrets often carry a trailing newline
+          secrets: ${{ format('{{"EXPORTER_WHITELIST_IPS":{0}}}', toJSON(secrets.EXPORTER_WHITELIST_IPS)) }}

--- a/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
+++ b/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
@@ -1,0 +1,14 @@
+bases:
+  - ../../helmfile-common.yaml
+---
+releases:
+  - name: scicat-exporter
+    namespace: scicat-{{ .Environment.Name }}
+    chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
+    version: 1.0.0
+    values:
+      - values.yaml
+      - {{ .Environment.Name }}/values.yaml
+      {{ if hasKey .Values "secrets" }}
+      - secretsJson: {{ .Values.secrets | toYaml | nindent 10 }}
+      {{ end }}

--- a/helm/helmfile-common.yaml
+++ b/helm/helmfile-common.yaml
@@ -1,0 +1,9 @@
+environments:
+  development:
+  qa:
+  production:
+
+helmDefaults:
+  atomic: true
+  wait: true
+  createNamespace: true


### PR DESCRIPTION
Step 1 of the step-by-step helmfile migration: swaps only scicat-exporter's deploy executor to helmfile via a new deploy-helmfile action (pinned download, run manually). One workflow per app stays. Linting, secrets, and the matrix follow as separate PRs.