### PR TITLE
feat: run opensearch resync from job

### DIFF
--- a/.github/workflows/scicat-be-next.yml
+++ b/.github/workflows/scicat-be-next.yml
@@ -67,6 +67,7 @@ jobs:
         AJV_CUSTOM_DEFINITIONS=helm/configs/backend-next/ajvCustomDefinitions.js
         MIGRATE_BROKEN_HISTORY=helm/configs/backend-next/migrate-broken-legacy-history.js
         OPENSEARCH_CONFIG=helm/configs/backend-next/opensearchConfig.json
+        OPENSEARCH_SYNC_JS=helm/configs/backend-next/opensearch-sync.js
     secrets:
       KUBECONFIG: ${{ secrets.KUBECONFIG }}
       JSON_SECRETS: ${{ toJSON(secrets) }}

--- a/helm/configs/backend-next/development/values.yaml
+++ b/helm/configs/backend-next/development/values.yaml
@@ -27,3 +27,4 @@ ingresses:
 migrateCommand: npm run migrate:db:up
 
 opensearchEnabled: "yes"
+opensearchSyncCommand: node /home/node/app/opensearch-sync.js

--- a/helm/configs/backend-next/opensearch-sync.js
+++ b/helm/configs/backend-next/opensearch-sync.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+require("dotenv").config({ path: "/home/node/app/.env" });
+
+const HOST = process.env.SCICAT_HOST;
+const INDEX = process.env.OPENSEARCH_INDEX;
+const FUNCTIONAL_ACCOUNTS_FILE = "/home/node/app/functionalAccounts.json";
+
+if (!HOST) fail("Missing required env var: SCICAT_HOST");
+if (!INDEX) fail("Missing required env var: OPENSEARCH_INDEX");
+if (!FUNCTIONAL_ACCOUNTS_FILE) fail("Missing required env var: FUNCTIONAL_ACCOUNTS_FILE");
+
+const ADMIN_GROUPS = (process.env.ADMIN_GROUPS || "")
+  .split(",")
+  .map((s) => s.trim())
+  .filter(Boolean);
+if (ADMIN_GROUPS.length === 0) fail("ADMIN_GROUPS not found or empty in .env");
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+const accounts = JSON.parse(fs.readFileSync(FUNCTIONAL_ACCOUNTS_FILE, "utf8"));
+const account = accounts.find((a) => {
+  const roles = Array.isArray(a.role) ? a.role : [a.role];
+  return roles.some((r) => ADMIN_GROUPS.includes(r));
+});
+if (!account) fail("No functional account found for admin groups");
+const USERNAME = account.username;
+const PASSWORD = account.password;
+
+const RETRIES = 30;
+const DELAY_MS = 10_000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function retry(desc, fn, okCodes = [200, 201]) {
+  for (let attempt = 1; attempt <= RETRIES; attempt++) {
+    try {
+      const resp = await fn();
+      if (okCodes.includes(resp.status)) {
+        return resp;
+      }
+      console.error(
+        `[${desc}] attempt ${attempt}/${RETRIES} got ${resp.status}, retrying in ${DELAY_MS / 1000}s...`
+      );
+    } catch (err) {
+      console.error(
+        `[${desc}] attempt ${attempt}/${RETRIES} error: ${err.message}, retrying in ${DELAY_MS / 1000}s...`
+      );
+    }
+    await sleep(DELAY_MS);
+  }
+  fail(`[${desc}] failed after ${RETRIES} attempts`);
+}
+
+async function main() {
+  console.log("Waiting for SciCat BE health...");
+  await retry("health", () => fetch(`${HOST}/api/v3/health`));
+
+  console.log("Logging in...");
+  const loginResp = await retry("login", () =>
+    fetch(`${HOST}/api/v3/auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ username: USERNAME, password: PASSWORD }),
+    })
+  );
+  const { access_token: token } = await loginResp.json();
+  const headers = { Authorization: `Bearer ${token}` };
+
+  console.log(`Deleting index ${INDEX} (if it exists)...`);
+  const qs = new URLSearchParams({ index: INDEX }).toString();
+  const delResp = await retry(
+    "delete-index",
+    () =>
+      fetch(`${HOST}/api/v3/opensearch/delete-index?${qs}`, {
+        method: "POST",
+        headers,
+      }),
+    [200, 400]
+  );
+  if (delResp.status === 400) {
+    console.log(`Index ${INDEX} did not exist, nothing to delete.`);
+  }
+
+  console.log(`Creating index ${INDEX}...`);
+  await retry("create-index", () =>
+    fetch(`${HOST}/api/v3/opensearch/create-index`, {
+      method: "POST",
+      headers: { ...headers, "Content-Type": "application/json" },
+      body: JSON.stringify({ index: INDEX }),
+    })
+  );
+
+  console.log("Syncing database into OpenSearch...");
+  const syncResp = await retry("sync-database", () =>
+    fetch(`${HOST}/api/v3/opensearch/sync-database?${qs}`, {
+      method: "POST",
+      headers,
+    })
+  );
+  const result = await syncResp.json();
+  console.log(
+    `Synced ${result.successful} of ${result.total} documents ` +
+      `(${result.failed} failed, took ${result.time}ms).`
+  );
+}
+
+main().catch((err) => fail(err.stack || err.message));

--- a/helm/configs/backend-next/values.yaml
+++ b/helm/configs/backend-next/values.yaml
@@ -32,6 +32,7 @@ configMaps:
   "{{ .Release.Name }}-migrations-cm":
     20250819165001-rename-measurement-id.js: "{{ .Values.RENAME_MEASUREMENT_ID_JS }}"
     20260127161201-migrate-broken-legacy-history.js: "{{ .Values.MIGRATE_BROKEN_HISTORY }}"
+    opensearch-sync.js: "{{ .Values.OPENSEARCH_SYNC_JS }}"
 
 secrets:
   "{{ .Release.Name }}-s":
@@ -48,12 +49,12 @@ ingresses:
       nginx.ingress.kubernetes.io/proxy-body-size: 50m
     hosts:
       - host: "{{ .Values.host }}"
-        paths: 
+        paths:
           - path: "/"
             pathType: Prefix
     tls:
       - hosts:
-        - "{{ .Values.host }}"
+          - "{{ .Values.host }}"
         secretName: "scicat-be-next-certificate"
   - enabled: true
     name: backend-next-login
@@ -114,6 +115,7 @@ volumeMounts:
     subPath: opensearchConfig.json
 
 migrateCommand: "echo 'No migration command specified.'"
+opensearchSyncCommand: "echo 'No OpenSearch sync command specified.'"
 
 jobContainers:
   - name: migrate
@@ -126,7 +128,13 @@ jobContainers:
       - >-
         npm run migrate:db:status &&
         {{ .Values.migrateCommand }} &&
-        npm run migrate:db:status
+        npm run migrate:db:status &&
+        {{ .Values.opensearchSyncCommand }}
+    env:
+      - name: SCICAT_HOST
+        value: http://backend-next.scicat-{{ .Values.envValue }}
+      - name: OPENSEARCH_INDEX
+        value: "dataset-{{ .Values.envValue }}"
     volumeMounts:
       - name: secrets-volume
         mountPath: /home/node/app/.env
@@ -137,7 +145,12 @@ jobContainers:
       - name: migrations-volume
         mountPath: /home/node/app/migrations/20260127161201-migrate-broken-legacy-history.js
         subPath: 20260127161201-migrate-broken-legacy-history.js
-
+      - name: migrations-volume
+        mountPath: /home/node/app/opensearch-sync.js
+        subPath: opensearch-sync.js
+      - name: secrets-volume
+        mountPath: /home/node/app/functionalAccounts.json
+        subPath: functionalAccounts.json
 
 # Keep the pre-rename chart name so selectors and resource names still match
 # releases installed from the vendored charts (Deployment selectors are immutable).


### PR DESCRIPTION
Rather than running the sync manually on any index change, this is run when enabled, usually when there are changes in OPENSEARCH_CONFIG. It is written as a JS script so that later it can be moved to scicat-backend upstream and run with npm 