### PR TITLE
chore: stop hiding the deploy output

### DIFF
--- a/.github/actions/deploy-helmfile/action.yml
+++ b/.github/actions/deploy-helmfile/action.yml
@@ -50,10 +50,8 @@ runs:
           state_values=(--state-values-file "$RUNNER_TEMP/state-values.yaml")
         fi
 
-        # helm dumps the fully rendered template on failure, credentials
-        # included, so its output stays hidden while secrets still reach it.
         if ! helmfile --file "$FILE" --environment "$ENVIRONMENT" \
-             "${state_values[@]}" sync &> /dev/null; then
+             "${state_values[@]}" sync; then
           echo "::error::helmfile sync failed for $FILE (environment: $ENVIRONMENT)"
           exit 1
         fi


### PR DESCRIPTION
Secrets move to plain text, so GitHub masks the value that actually renders and the redirect stops earning anything. Depends on #632, the exporter needs its plain secret first.