### PR TITLE
fix: stop escaping the changed-files json consumed by jq

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           files: helm/configs/**
           dir_names: true
           dir_names_max_depth: 3
-          json: true
+          matrix: true
 
       - name: Select helmfile states to render
         id: states


### PR DESCRIPTION
`json: true` leaves `escape_json` at its default, so the value arrived as `[\"helm/configs/...\"]` and the `jq` consuming it failed. `matrix: true` is the documented alias for json output without the escaping.