### PR TITLE
feat: deploy scicat-exporter with a plain whitelist secret

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,8 @@ jobs:
           set -euo pipefail
 
           # Configs dereference .Values.secretsJson.<KEY> unconditionally, so a render
-          # needs every key present, and the chart b64-decodes them.
+          # needs every key present. The value is base64 because a `secrets:` block
+          # feeds a k8s Secret, which rejects anything else.
           grep -rhoE 'secretsJson\.[A-Za-z0-9_]+' helm/configs \
             | cut -d. -f2 | sort -u | jq -R . \
             | jq -s '{secrets: (map({key: ., value: "ZHVtbXk="}) | from_entries)}' \

--- a/.github/workflows/scicat-exporter.yml
+++ b/.github/workflows/scicat-exporter.yml
@@ -50,4 +50,4 @@ jobs:
           environment: "${{ needs.set_env.outputs.environment }}"
           kubeconfig: "${{ secrets.KUBECONFIG }}"
           # toJSON quotes and escapes the value, secrets often carry a trailing newline
-          secrets: ${{ format('{{"EXPORTER_WHITELIST_IPS":{0}}}', toJSON(secrets.EXPORTER_WHITELIST_IPS)) }}
+          secrets: ${{ format('{{"EXPORTER_WHITELIST_CIDRS":{0}}}', toJSON(secrets.EXPORTER_WHITELIST_CIDRS)) }}

--- a/helm/configs/scicat-exporter/development/values.yaml
+++ b/helm/configs/scicat-exporter/development/values.yaml
@@ -10,7 +10,7 @@ env:
 
 ingress:
   annotations:
-    b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.EXPORTER_WHITELIST_IPS }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.EXPORTER_WHITELIST_CIDRS }}"
   hosts:
     - host: "{{ .Values.host }}"
       paths:

--- a/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
+++ b/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
@@ -5,7 +5,7 @@ releases:
   - name: scicat-exporter
     namespace: scicat-{{ .Environment.Name }}
     chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
-    version: 1.0.0
+    version: 2.0.0
     values:
       - values.yaml
       - {{ .Environment.Name }}/values.yaml


### PR DESCRIPTION
The whitelist CIDRs move from a base64 secret to a plain one, so GitHub masks the value it actually renders. Needs `EXPORTER_WHITELIST_CIDRS` in the development environment, and [dc-charts#9](https://github.com/paulscherrerinstitute/dc-charts/pull/9) merged so generic-service 2.0.0 exists.