### PR TITLE
Rename LBEM site in globus-proxy

### DIFF
--- a/helm/configs/globus-proxy/development/config.yaml
+++ b/helm/configs/globus-proxy/development/config.yaml
@@ -39,5 +39,5 @@ facilities:
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
   - <<: *openemFacility
-    name: LBEM
+    name: EPFL-LBEM
     collection: ed650f52-0235-4c40-a573-5f8de55841a6

--- a/helm/configs/globus-proxy/production/config.yaml
+++ b/helm/configs/globus-proxy/production/config.yaml
@@ -30,5 +30,5 @@ facilities:
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
   - <<: *openemFacility
-    name: LBEM
+    name: EPFL-LBEM
     collection: ed650f52-0235-4c40-a573-5f8de55841a6

--- a/helm/configs/globus-proxy/qa/config.yaml
+++ b/helm/configs/globus-proxy/qa/config.yaml
@@ -30,5 +30,5 @@ facilities:
     name: EMPA
     collection: ed650f52-0235-4c40-a573-5f8de55841a6
   - <<: *openemFacility
-    name: LBEM
+    name: EPFL-LBEM
     collection: ed650f52-0235-4c40-a573-5f8de55841a6


### PR DESCRIPTION
Currently facility names need to match the keycloak group.