### PR TITLE
chore: enable s3-broker ingress in qa and prod

### DIFF
--- a/helm/configs/s3-broker/production/values.yaml
+++ b/helm/configs/s3-broker/production/values.yaml
@@ -6,6 +6,3 @@ scicat:
 
 upload_bucket: psi-upload
 retrieve_bucket: psi-retrieve
-
-ingress:
-  enabled: false

--- a/helm/configs/s3-broker/qa/values.yaml
+++ b/helm/configs/s3-broker/qa/values.yaml
@@ -6,6 +6,3 @@ scicat:
 
 upload_bucket: psi-upload-qa
 retrieve_bucket: psi-retrieve-qa
-
-ingress:
-  enabled: false


### PR DESCRIPTION
the /datasets/s3-creds endpoint is now needed for scicat-cli's s3 upload functionality

need to make sure the github secret for `S3_BROKER_CREDENTIALS` is available in qa and prod environments 