### PR TITLE
fix: scope the exporter whitelist secret to development

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -98,15 +98,31 @@ Four rules that nothing enforces. Read them before you set `sourceRepo`.
 
 ### Secrets
 
-`deploy.yml` passes every secret of the environment to the state. A release lists
-the secrets its chart receives.
+`deploy.yml` passes every secret of the environment to the state. A release names
+the ones its chart receives, one key per line.
 
 ```gotmpl
-      {{ if hasKey .Values "secrets" }}
+      - secretsJson:
+          COMPONENT_CONFIG: {{ .Values.secrets.COMPONENT_CONFIG | quote }}
+          DATASOURCES: {{ .Values.secrets.DATASOURCES | quote }}
+```
+
+A secret that only one environment defines needs a guard, or the other environments
+stop on the missing key.
+
+```gotmpl
+      {{ if eq .Environment.Name "development" }}
       - secretsJson:
           EXPORTER_WHITELIST_CIDRS: {{ .Values.secrets.EXPORTER_WHITELIST_CIDRS | quote }}
       {{ end }}
 ```
+
+Keep both forms below the `---`. Helmfile renders the whole `environments:` block
+before it selects an environment, so a `.Values.secrets` read up there runs for every
+deploy and stops qa on a key only development defines.
+
+A missing key always stops the render. That is the wanted behaviour, an empty
+whitelist annotation opens the ingress.
 
 The encoding depends on where the value lands. A value in the chart's `secrets:`
 block must be base64, and the chart stops the render if it is not. A value used

--- a/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
+++ b/helm/configs/scicat-exporter/helmfile.yaml.gotmpl
@@ -9,8 +9,8 @@ releases:
     values:
       - values.yaml
       - {{ .Environment.Name }}/values.yaml
-      # The deploy passes every secret of the environment. This release reads one.
-      {{ if hasKey .Values "secrets" }}
+      # Only development restricts the exporter by source range.
+      {{ if eq .Environment.Name "development" }}
       - secretsJson:
           EXPORTER_WHITELIST_CIDRS: {{ .Values.secrets.EXPORTER_WHITELIST_CIDRS | quote }}
       {{ end }}


### PR DESCRIPTION
The state asked for EXPORTER_WHITELIST_CIDRS in every environment, but only
development defines it, so qa deploys fail. An environment now declares the
secrets it reads in `secretKeys`.

`required` is there because `index` returns an empty string for a missing key,
and an empty whitelist annotation opens the ingress.
