### PR TITLE
chore: read the image values inside the build hook

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -42,15 +42,14 @@ alone.
 ### Deploy a commit that nobody published
 
 Set the source repository, and point `image` in `values.yaml` at the commit to
-build. The state loads `values.yaml` as well, because the hook reads `image` from
-there. Set only the environments that build, because the others keep the pinned
-image.
+build. The hook reads `image` out of the same values files the release lists, so the
+state names the source repository alone. Set only the environments that build,
+because the others keep the pinned image.
 
 ```gotmpl
 environments:
   development:
     values:
-      - values.yaml
       - sourceRepo: https://github.com/SciCatProject/backend
 ---
 releases:

--- a/helm/configs/search-api/helmfile.yaml.gotmpl
+++ b/helm/configs/search-api/helmfile.yaml.gotmpl
@@ -5,7 +5,6 @@ bases:
 environments:
   development:
     values:
-      - values.yaml
       - sourceRepo: https://github.com/SciCatProject/panosc-search-api
 ---
 releases:

--- a/helm/helmfile-common.yaml
+++ b/helm/helmfile-common.yaml
@@ -17,6 +17,10 @@ helmDefaults:
 # A published image always wins, the build only covers what nobody published.
 #
 # The expressions below resolve when the hook runs, not when this file is read.
+#
+# The hook reads the same two values files the release does, in the same order, so
+# a state does not have to load them a second time under `environments:`. A path is
+# relative to the state file, and a missing one stops the render.
 templates:
   build:
     hooks:
@@ -27,12 +31,15 @@ templates:
           - -c
           - |
             set -euo pipefail
-            image="{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+            {{- $base := readFile "values.yaml" | fromYaml }}
+            {{- $overlay := readFile (printf "%s/values.yaml" .Environment.Name) | fromYaml }}
+            {{- $values := mergeOverwrite $base $overlay }}
+            image="{{ $values.image.repository }}:{{ $values.image.tag }}"
             if docker buildx imagetools inspect "$image" >/dev/null 2>&1; then
               echo "$image exists, skipping build"
               exit 0
             fi
             docker buildx build --push --tag "$image" \
-              --label "org.opencontainers.image.revision={{ .Values.image.tag }}" \
+              --label "org.opencontainers.image.revision={{ $values.image.tag }}" \
               --label "org.opencontainers.image.source={{ .Values.sourceRepo }}" \
-              "{{ .Values.sourceRepo }}.git#{{ .Values.image.tag }}"
+              "{{ .Values.sourceRepo }}.git#{{ $values.image.tag }}"


### PR DESCRIPTION
The hook reads `image` out of the same values files the release lists, so a state no longer loads `values.yaml` a second time under `environments:`.