### PR TITLE
chore: remove the scicat-backend-next submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "oaipmh"]
 	path = oaipmh
 	url = https://github.com/SciCatProject/oai-provider-service.git
-[submodule "scicat-backend-next"]
-	path = scicat-backend-next
-	url = https://github.com/SciCatProject/scicat-backend-next
 [submodule "landing-page-server"]
 	path = landing-page-server
 	url = https://github.com/SciCatProject/LandingPageServer.git


### PR DESCRIPTION
The component builds from `sourceRepo` since #650.