### PR TITLE
chore: pin pss to generic-service 2.0.0

### DIFF
--- a/helm/configs/pss/helmfile.yaml.gotmpl
+++ b/helm/configs/pss/helmfile.yaml.gotmpl
@@ -5,7 +5,7 @@ releases:
   - name: pss
     namespace: scicat-{{ .Environment.Name }}
     chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
-    version: 1.0.0
+    version: 2.0.0
     values:
       - values.yaml
       - secretsJson:


### PR DESCRIPTION
pss has no ingress whitelist, so the bump needs no secret change.