### PR TITLE
fix: migrate globus-proxy to generic-service 2.0.0 and a plain whitelist

### DIFF
--- a/helm/configs/globus-proxy/development/values.yaml
+++ b/helm/configs/globus-proxy/development/values.yaml
@@ -2,4 +2,4 @@ host: globus-proxy.development.psi.ch
 
 ingress:
   annotations:
-    b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.OPENEM_WHITELISTED_IPS }}"
+    nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.OPENEM_WHITELISTED_CIDRS }}"

--- a/helm/configs/globus-proxy/helmfile.yaml.gotmpl
+++ b/helm/configs/globus-proxy/helmfile.yaml.gotmpl
@@ -5,14 +5,14 @@ releases:
   - name: globus-proxy
     namespace: scicat-{{ .Environment.Name }}
     chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
-    version: 1.0.0
+    version: 2.0.0
     values:
       - values.yaml
       - {{ .Environment.Name }}/values.yaml
       - secretsJson:
           GLOBUS_PROXY_ENV: {{ .Values.secrets.GLOBUS_PROXY_ENV | quote }}
           {{- if eq .Environment.Name "development" }}
-          OPENEM_WHITELISTED_IPS: {{ .Values.secrets.OPENEM_WHITELISTED_IPS | quote }}
+          OPENEM_WHITELISTED_CIDRS: {{ .Values.secrets.OPENEM_WHITELISTED_CIDRS | quote }}
           {{- end }}
     set:
       - name: CONFIG


### PR DESCRIPTION
Chart 1.0.0 templates the whole ingress annotation map at once, so a template error on any annotation prints every value on that Ingress. The whitelist moves to `OPENEM_WHITELISTED_CIDRS`, plain text on development.