### PR TITLE
fix: migrate backend-next to generic-service 2.0.0 and plain whitelists

### DIFF
--- a/helm/configs/backend-next/development/values.yaml
+++ b/helm/configs/backend-next/development/values.yaml
@@ -13,7 +13,7 @@ ingresses:
       cert-manager.io/cluster-issuer: letsencrypt-prod
       nginx.ingress.kubernetes.io/proxy-body-size: 50m
       nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
-      b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.OPENEM_WHITELISTED_IPS }}"
+      nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.OPENEM_WHITELISTED_CIDRS }}"
     hosts:
       - host: "{{ .Values.host }}"
         paths: 

--- a/helm/configs/backend-next/helmfile.yaml.gotmpl
+++ b/helm/configs/backend-next/helmfile.yaml.gotmpl
@@ -11,7 +11,7 @@ releases:
   - name: backend-next
     namespace: scicat-{{ .Environment.Name }}
     chart: oci://ghcr.io/paulscherrerinstitute/dc-charts/generic-service
-    version: 1.0.0
+    version: 2.0.0
     {{ if .Values.sourceRepo }}
     inherit:
       - template: build
@@ -22,10 +22,10 @@ releases:
       - secretsJson:
           BENEXT_ENV: {{ .Values.secrets.BENEXT_ENV | quote }}
           BENEXT_FUNCTIONAL_ACCOUNTS: {{ .Values.secrets.BENEXT_FUNCTIONAL_ACCOUNTS | quote }}
-          WHITELISTED_IPS: {{ .Values.secrets.WHITELISTED_IPS | quote }}
+          WHITELISTED_CIDRS: {{ .Values.secrets.WHITELISTED_CIDRS | quote }}
           # Only development restricts the OpenEM route by source range.
           {{- if eq .Environment.Name "development" }}
-          OPENEM_WHITELISTED_IPS: {{ .Values.secrets.OPENEM_WHITELISTED_IPS | quote }}
+          OPENEM_WHITELISTED_CIDRS: {{ .Values.secrets.OPENEM_WHITELISTED_CIDRS | quote }}
           {{- end }}
     set:
       - name: JOB_TEMPLATE

--- a/helm/configs/backend-next/values.yaml
+++ b/helm/configs/backend-next/values.yaml
@@ -62,7 +62,7 @@ ingresses:
     name: backend-next-login
     annotations:
       kubernetes.io/ingress.class: nginx
-      b64/nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.WHITELISTED_IPS }}"
+      nginx.ingress.kubernetes.io/whitelist-source-range: "{{ .Values.secretsJson.WHITELISTED_CIDRS }}"
     hosts:
       - host: "{{ .Values.host }}"
         paths:


### PR DESCRIPTION
Chart 1.0.0 templates the whole ingress annotation map at once, so a template error on any annotation prints every value on that Ingress. The login route moves to `WHITELISTED_CIDRS` in all three environments, the development route to `OPENEM_WHITELISTED_CIDRS`.