### PR TITLE
chore: remove the pan-ontologies-api submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "frontend"]
 	path = frontend
 	url = https://github.com/SciCatProject/frontend.git
-[submodule "pan-ontologies-api"]
-	path = pan-ontologies-api
-	url = https://github.com/ExPaNDS-eu/pan-ontologies-api.git
 [submodule "oaipmh"]
 	path = oaipmh
 	url = https://github.com/SciCatProject/oai-provider-service.git


### PR DESCRIPTION
Its migration merged in #658. Nothing outside `.gitmodules` names the path.