### PR TITLE
fix: reduce maximum parallel deployments from 6 to 3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -103,7 +103,7 @@ jobs:
     strategy:
       fail-fast: false
       # Every deploy opens an ssh tunnel to the same bastion.
-      max-parallel: 6
+      max-parallel: 3
       matrix:
         component: ${{ fromJSON(needs.discover.outputs.components) }}
     concurrency:


### PR DESCRIPTION
Started getting SSH errors with too many connections at the same time.