### PR TITLE
feat: add first implementation of mark cronjob

### DIFF
--- a/.github/workflows/retention-test.yml
+++ b/.github/workflows/retention-test.yml
@@ -1,0 +1,50 @@
+name: retention-test
+
+# lint.yml renders the helm state. This covers the python source the hook builds.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/retention-test.yml
+      - retention/**
+
+permissions:
+  contents: read
+
+jobs:
+
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: retention
+    steps:
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build
+        run: |
+          cp docker-compose.dev.yml docker-compose.yml
+          docker compose up -d --build
+
+      - name: Test
+        run: docker compose exec -T app pytest
+
+      - name: Black
+        run: docker compose exec -T app black --check --diff --no-color ./src
+
+      - name: Isort
+        run: docker compose exec -T app isort --check --diff ./src
+
+      - name: Pylint
+        run: docker compose exec -T app pylint ./src
+        continue-on-error: true
+
+      - name: Build prod
+        run: docker build -t prod .
+
+      - name: Cleanup
+        if: ${{ always() }}
+        run: docker compose down

--- a/retention/README.md
+++ b/retention/README.md
@@ -40,6 +40,11 @@ check against `creationTime + retentionTime` on every check-in.
   `delete` for its remaining datasets — with one final safety check that
   filters out any dataset whose status isn't `markedForDeletion` — instead
   of just flagging the job as `retentionExpired`.
+- Paginating `due_jobs()`. The jobs endpoint caps a single response at 100
+  results, so once there are more due jobs than that in one run, this
+  service silently only sees the first page. It needs a `skip`/`limit`
+  iterator over the loopback filter's `limits`, yielding page by page (with
+  a max-iterations safety cap) until an empty page comes back.
 
 This first version simply lets every due job run its grace period out
 unconditionally.

--- a/retention/README.md
+++ b/retention/README.md
@@ -1,0 +1,75 @@
+# A cronjob re-confirming datasets marked for deletion until their retention period expires
+
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
+## Workflow
+
+1. In the frontend, a user selects datasets and clicks "mark for deletion".
+   This creates a SciCat job with `type`: `markedForDeletion` and
+   `datasetList`: the selected datasets.
+2. A RabbitMQ listener picks up the job on creation: it patches each dataset,
+   setting `datasetlifecycle.archiveStatusMessage` to `markedForDeletion`,
+   and writes onto the job itself both the grace period as
+   `jobResultObject.retentionTime`, e.g. `{"value": 3, "unit": "M"}` for 3
+   months (`unit` follows the same calendar (uppercase `Y`/`M`) vs. clock
+   (lowercase `d`/`h`/`m`/`s`) convention ISO 8601 durations use), and an
+   initial `jobResultObject.lastVerifiedAt` timestamp, the baseline the first
+   check-in is measured from. Until `lastVerifiedAt` is set, this service's
+   query simply never selects the job — not an error, just a job the
+   listener hasn't processed yet.
+3. This service runs periodically (e.g. daily, via a cronjob) and fetches
+   every `markedForDeletion` job whose `lastVerifiedAt` is at least one
+   retention step old — that condition is a `where` clause in the query
+   itself, not a check done after fetching. For each job returned, it
+   records the check-in as `jobResultObject.lastVerifiedAt` (the only kind
+   of field the v3 API lets be patched after creation, alongside
+   `jobStatusMessage`). If the job's full `retentionTime` grace period has
+   elapsed since `creationTime`, its `jobStatusMessage` is set to
+   `retentionExpired` — the signal for whichever downstream process performs
+   the actual deletion.
+
+Check-ins happen once every retention step (currently 1 month), independently
+of `retentionTime`'s own unit — a job with `retentionTime`
+`{"value": 1, "unit": "Y"}` is still re-checked monthly throughout the year,
+not just once at the end. Whether the job has actually expired is a separate
+check against `creationTime + retentionTime` on every check-in.
+
+**Not yet implemented:**
+
+- Re-verifying, on every check-in, that the datasets in a job are still
+  flagged with `archiveStatusMessage == "markedForDeletion"`. Any dataset
+  whose status no longer matches should have its entry removed from the
+  job's `datasetList`, rather than stopping the whole job.
+- Filtering out jobs whose `datasetList` is empty (e.g. once the above has
+  pruned every entry).
+- Once a job's retention period has passed, submitting a new job of type
+  `delete` for its remaining datasets — with one final safety check that
+  filters out any dataset whose status isn't `markedForDeletion` — instead
+  of just flagging the job as `retentionExpired`.
+
+This first version simply lets every due job run its grace period out
+unconditionally.
+
+## Getting started
+
+The easiest way to set up a dev environment is to use the provided compose file.
+
+```bash
+docker-compose -f docker-compose.dev.yml up --build
+```
+
+## Docker
+
+Variables to be supplied for docker run:
+
+- SCICAT_ENDPOINT
+- SCICAT_USERNAME
+- SCICAT_PASSWORD
+
+```bash
+IMAGE_NAME=<IMAGE_NAME>
+docker build -t $IMAGE_NAME .
+docker run -e "SCICAT_ENDPOINT=<SCICAT_ENDPOINT>" -e "SCICAT_USERNAME=<SCICAT_USERNAME>" \
+-e "SCICAT_PASSWORD=<SCICAT_PASSWORD>" \
+$IMAGE_NAME python main.py
+```

--- a/retention/README.md
+++ b/retention/README.md
@@ -18,15 +18,15 @@
    query simply never selects the job — not an error, just a job the
    listener hasn't processed yet.
 3. This service runs periodically (e.g. daily, via a cronjob) and fetches
-   every `markedForDeletion` job whose `lastVerifiedAt` is at least one
-   retention step old — that condition is a `where` clause in the query
-   itself, not a check done after fetching. For each job returned, it
-   records the check-in as `jobResultObject.lastVerifiedAt` (the only kind
-   of field the v3 API lets be patched after creation, alongside
-   `jobStatusMessage`). If the job's full `retentionTime` grace period has
-   elapsed since `creationTime`, its `jobStatusMessage` is set to
-   `retentionExpired` — the signal for whichever downstream process performs
-   the actual deletion.
+   every `markedForDeletion` job whose `datasetList` isn't empty and whose
+   `lastVerifiedAt` is at least one retention step old — those conditions
+   are `where` clauses in the query itself, not a check done after
+   fetching. For each job returned, it records the check-in as
+   `jobResultObject.lastVerifiedAt` (the only kind of field the v3 API lets
+   be patched after creation, alongside `jobStatusMessage`). If the job's
+   full `retentionTime` grace period has elapsed since `creationTime`, its
+   `jobStatusMessage` is set to `retentionExpired` — the signal for
+   whichever downstream process performs the actual deletion.
 
 Check-ins happen once every retention step (currently 1 month), independently
 of `retentionTime`'s own unit — a job with `retentionTime`
@@ -36,12 +36,6 @@ check against `creationTime + retentionTime` on every check-in.
 
 **Not yet implemented:**
 
-- Re-verifying, on every check-in, that the datasets in a job are still
-  flagged with `archiveStatusMessage == "markedForDeletion"`. Any dataset
-  whose status no longer matches should have its entry removed from the
-  job's `datasetList`, rather than stopping the whole job.
-- Filtering out jobs whose `datasetList` is empty (e.g. once the above has
-  pruned every entry).
 - Once a job's retention period has passed, submitting a new job of type
   `delete` for its remaining datasets — with one final safety check that
   filters out any dataset whose status isn't `markedForDeletion` — instead

--- a/retention/src/main.py
+++ b/retention/src/main.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+"""
+Entry point for the dataset retention cronjob.
+
+This script checks SciCat jobs of type "markedForDeletion" and advances (or
+cancels) their retention countdown, one step towards the eventual hard
+deletion of the underlying datasets.
+
+Usage:
+    python main.py
+"""
+
+from orchestrator import RetentionOrchestrator
+
+
+def main():
+    """Initializes and runs the RetentionOrchestrator."""
+    RetentionOrchestrator().orchestrate()
+
+
+if __name__ == "__main__":
+    main()

--- a/retention/src/orchestrator.py
+++ b/retention/src/orchestrator.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timezone
+
+from scicat import MarkedForDeletionJobsRepository, SciCatAuth
+from utils import log
+
+
+class RetentionOrchestrator:
+    """
+    Updates the verification time of "markedForDeletion" jobs due for a
+    check-in, until their grace period expires.
+
+    Which jobs are due is decided by the database query itself.
+    """
+
+    def __init__(self):
+        self.scicat_instance = SciCatAuth.from_env()
+        self.jobs = MarkedForDeletionJobsRepository()
+
+    def orchestrate(self):
+        """Updates every due markedForDeletion job's verification time."""
+        log.info("==== Retention check started ====")
+        log.info(f"Connecting to scicat on {self.scicat_instance.url}")
+        self.scicat_instance.authenticate()
+        now = datetime.now(timezone.utc)
+        due_jobs = self.jobs.due_jobs(now)
+        log.info(f"{len(due_jobs)} job(s) due for a check-in")
+        for job in due_jobs:
+            try:
+                job.advance(now)
+            except Exception as e:
+                log.error(f"Failed to process job {job.id}: {e}")
+        log.info("==== Retention check finished ====")

--- a/retention/src/scicat.py
+++ b/retention/src/scicat.py
@@ -1,0 +1,175 @@
+import json
+from os import environ
+
+from dateutil.relativedelta import relativedelta
+from dotenv import load_dotenv
+from scicat_sdk_py import AuthApi, Configuration, JobsApi
+
+from utils import log
+
+JOB_TYPE = "markedForDeletion"
+
+RESULT_RETENTION_TIME = "retentionTime"
+RESULT_LAST_VERIFIED_AT = "lastVerifiedAt"
+
+STATUS_RETENTION_EXPIRED = "retentionExpired"
+
+# retentionTime suffix -> relativedelta keyword, following the same calendar
+# (upper) vs clock (lower) case convention as ISO 8601 durations.
+_RELATIVEDELTA_KWARG_BY_UNIT = {
+    "Y": "years",
+    "M": "months",
+    "d": "days",
+    "h": "hours",
+    "m": "minutes",
+    "s": "seconds",
+}
+
+
+def _parse_retention(retention_time):
+    """Validates e.g. {"value": 3, "unit": "M"} and returns (3, "months")."""
+    try:
+        amount = retention_time["value"]
+        unit = retention_time["unit"]
+    except (TypeError, KeyError) as e:
+        raise ValueError(
+            f"Unrecognized retention time format: {retention_time!r}"
+        ) from e
+    kwarg = _RELATIVEDELTA_KWARG_BY_UNIT.get(unit)
+    if kwarg is None or not isinstance(amount, int) or isinstance(amount, bool):
+        raise ValueError(f"Unrecognized retention time format: {retention_time!r}")
+    return amount, kwarg
+
+
+_RETENTION_STEP = {"value": 1, "unit": "M"}
+_RETENTION_STEP_DELTA = relativedelta(
+    **{_RELATIVEDELTA_KWARG_BY_UNIT[_RETENTION_STEP["unit"]]: _RETENTION_STEP["value"]}
+)
+
+
+class SciCatAuth:
+    """
+    Handles authentication with the SciCat API.
+
+    Attributes:
+        username (str): Username for SciCat.
+        password (str): Password for SciCat.
+        url (str): SciCat endpoint URL.
+    """
+
+    def __init__(self, username, password, url):
+        self.username = username
+        self.password = password
+        self.url = url
+
+    @classmethod
+    def from_env(cls):
+        """Creates a SciCatAuth instance from environment variables."""
+        load_dotenv()
+        log.info("Loading scicat env vars")
+        return cls(
+            environ["SCICAT_USERNAME"],
+            environ["SCICAT_PASSWORD"],
+            environ["SCICAT_ENDPOINT"],
+        )
+
+    def authenticate(self):
+        """Authenticates with SciCat and sets the token in the API client."""
+        self._set_scicat_token()
+
+    def _get_scicat_token(self):
+        """Retrieves the authentication token from SciCat."""
+        credentials = {"username": self.username, "password": self.password}
+        try:
+            response = AuthApi().auth_controller_login_v3(credentials)
+            return response.access_token
+        except Exception as e:
+            log.error("Login to data catalog did not succeed")
+            raise e
+
+    def _set_scicat_token(self):
+        """Sets the SciCat token in the Swagger client configuration."""
+        scicat_config = Configuration(host=self.url)
+        Configuration.set_default(scicat_config)
+        access_token = self._get_scicat_token()
+        log.info("SciCat authentication successful, setting access_token")
+        Configuration.get_default().access_token = access_token
+
+
+class MarkedForDeletionJob:
+    """
+    Wraps a "markedForDeletion" SciCat job and tracks its retention grace period.
+    """
+
+    def __init__(self, job):
+        self._job = job
+
+    @property
+    def id(self):
+        return self._job.id
+
+    @property
+    def dataset_pids(self):
+        return [dataset.pid for dataset in self._job.dataset_list]
+
+    @property
+    def retention_time(self):
+        return self._job.job_result_object.get(RESULT_RETENTION_TIME)
+
+    @property
+    def retention_amount(self):
+        """The grace period's numeric value, e.g. 3 for {"value": 3, "unit": "M"}."""
+        return _parse_retention(self.retention_time)[0]
+
+    @property
+    def _retention_unit(self):
+        return _parse_retention(self.retention_time)[1]
+
+    @property
+    def expiry_date(self):
+        """The date at which the full retentionTime grace period has elapsed."""
+        return self._job.creation_time + relativedelta(
+            **{self._retention_unit: self.retention_amount}
+        )
+
+    def advance(self, now):
+        """Updates the job's verification time and checks whether its grace period has elapsed."""
+        patch = {
+            "jobResultObject": {
+                **self._job.job_result_object,
+                RESULT_LAST_VERIFIED_AT: now.isoformat(),
+            }
+        }
+        if now >= self.expiry_date:
+            patch["jobStatusMessage"] = STATUS_RETENTION_EXPIRED
+            log.info(f"Job {self.id} retention expired, ready for deletion")
+        else:
+            log.info(f"Job {self.id} verification time updated, not yet expired")
+        JobsApi().jobs_controller_update_v3(self.id, patch)
+
+
+class MarkedForDeletionJobsRepository:
+    """Fetches SciCat "markedForDeletion" jobs whose next check-in is due."""
+
+    @staticmethod
+    def _due_jobs_filter(now):
+        # lastVerifiedAt is written by the marking agent at job creation (as
+        # well as by this service on every check-in), so a due job is simply
+        # one whose last check-in is at least one retention step old.
+        return {
+            "where": {
+                "type": JOB_TYPE,
+                "jobStatusMessage": {"neq": STATUS_RETENTION_EXPIRED},
+                f"jobResultObject.{RESULT_LAST_VERIFIED_AT}": {
+                    "lte": (now - _RETENTION_STEP_DELTA).isoformat()
+                },
+            }
+        }
+
+    def due_jobs(self, now):
+        """Returns markedForDeletion jobs due for a check-in, as MarkedForDeletionJob."""
+        log.info("Fetching markedForDeletion jobs due for a check-in")
+        jobs = JobsApi().jobs_controller_find_all_v3(
+            filter=json.dumps(self._due_jobs_filter(now))
+        )
+        return [MarkedForDeletionJob(job) for job in jobs]

--- a/retention/src/scicat.py
+++ b/retention/src/scicat.py
@@ -160,6 +160,7 @@ class MarkedForDeletionJobsRepository:
             "where": {
                 "type": JOB_TYPE,
                 "jobStatusMessage": {"neq": STATUS_RETENTION_EXPIRED},
+                "datasetList": {"neq": []},
                 f"jobResultObject.{RESULT_LAST_VERIFIED_AT}": {
                     "lte": (now - _RETENTION_STEP_DELTA).isoformat()
                 },

--- a/retention/src/tests/fixtures/mocked_data.py
+++ b/retention/src/tests/fixtures/mocked_data.py
@@ -1,0 +1,30 @@
+from datetime import datetime, timezone
+from unittest.mock import Mock
+
+
+class FixturesJobs:
+
+    job_id = "job1"
+
+    creation_time = datetime(2026, 5, 24, tzinfo=timezone.utc)
+
+    dataset_pids = ["pid1", "pid2"]
+
+    @staticmethod
+    def raw_job(
+        job_result_object=None,
+        creation_time=None,
+        job_id=None,
+        dataset_pids=None,
+    ):
+        pids = dataset_pids if dataset_pids is not None else FixturesJobs.dataset_pids
+        return Mock(
+            id=job_id or FixturesJobs.job_id,
+            dataset_list=[Mock(pid=pid) for pid in pids],
+            job_result_object=(
+                job_result_object
+                if job_result_object is not None
+                else {"retentionTime": {"value": 3, "unit": "M"}}
+            ),
+            creation_time=creation_time or FixturesJobs.creation_time,
+        )

--- a/retention/src/tests/test_main.py
+++ b/retention/src/tests/test_main.py
@@ -1,0 +1,11 @@
+from unittest.mock import patch
+
+import main
+
+
+@patch("main.RetentionOrchestrator", autospec=True)
+def test_main(mock_orchestrator):
+    mock_instance = mock_orchestrator.return_value
+    main.main()
+    mock_orchestrator.assert_called_once()
+    mock_instance.orchestrate.assert_called_once()

--- a/retention/src/tests/test_orchestrator.py
+++ b/retention/src/tests/test_orchestrator.py
@@ -1,0 +1,49 @@
+import os
+from unittest.mock import ANY, Mock, patch
+
+import orchestrator
+
+
+class TestRetentionOrchestrator:
+
+    def setup_method(self):
+        self.env_patch = patch.dict(
+            os.environ,
+            {
+                "SCICAT_ENDPOINT": "http://scicat",
+                "SCICAT_USERNAME": "test_user",
+                "SCICAT_PASSWORD": "test_password",
+            },
+        )
+        self.env_patch.start()
+        self.orchestrator = orchestrator.RetentionOrchestrator()
+
+    def teardown_method(self):
+        self.env_patch.stop()
+
+    @patch("orchestrator.MarkedForDeletionJobsRepository.due_jobs", autospec=True)
+    @patch("orchestrator.SciCatAuth.authenticate", autospec=True)
+    def test_orchestrate_advances_every_due_job(self, mock_authenticate, mock_due_jobs):
+        job1, job2 = Mock(), Mock()
+        mock_due_jobs.return_value = [job1, job2]
+
+        self.orchestrator.orchestrate()
+
+        mock_authenticate.assert_called_once()
+        mock_due_jobs.assert_called_once_with(self.orchestrator.jobs, ANY)
+        job1.advance.assert_called_once_with(ANY)
+        job2.advance.assert_called_once_with(ANY)
+
+    @patch("orchestrator.log")
+    @patch("orchestrator.MarkedForDeletionJobsRepository.due_jobs", autospec=True)
+    @patch("orchestrator.SciCatAuth.authenticate", autospec=True)
+    def test_orchestrate_logs_and_continues_on_error(self, _, mock_due_jobs, mock_log):
+        failing_job = Mock(id="job1")
+        failing_job.advance.side_effect = Exception("boom")
+        other_job = Mock(id="job2")
+        mock_due_jobs.return_value = [failing_job, other_job]
+
+        self.orchestrator.orchestrate()
+
+        other_job.advance.assert_called_once_with(ANY)
+        mock_log.error.assert_called_once()

--- a/retention/src/tests/test_scicat.py
+++ b/retention/src/tests/test_scicat.py
@@ -179,6 +179,7 @@ class TestMarkedForDeletionJobsRepository:
             "where": {
                 "type": "markedForDeletion",
                 "jobStatusMessage": {"neq": "retentionExpired"},
+                "datasetList": {"neq": []},
                 "jobResultObject.lastVerifiedAt": {
                     "lte": (now - relativedelta(months=1)).isoformat()
                 },

--- a/retention/src/tests/test_scicat.py
+++ b/retention/src/tests/test_scicat.py
@@ -1,0 +1,186 @@
+import json
+import os
+from unittest.mock import ANY, Mock, patch
+
+import pytest
+from dateutil.relativedelta import relativedelta
+
+import scicat
+
+from .fixtures.mocked_data import FixturesJobs
+
+
+class TestSciCatAuth:
+
+    scicat_auth = scicat.SciCatAuth("test_user", "test_password", "http://scicat")
+
+    def test_init(self):
+        assert self.scicat_auth.username == "test_user"
+        assert self.scicat_auth.password == "test_password"
+        assert self.scicat_auth.url == "http://scicat"
+
+    @patch(
+        "scicat.AuthApi.auth_controller_login_v3",
+        return_value=Mock(access_token="test_token"),
+        autospec=True,
+    )
+    def test__get_scicat_token(self, mock_user_login):
+        access_token = self.scicat_auth._get_scicat_token()
+        assert access_token == "test_token"
+        mock_user_login.assert_called_once_with(
+            ANY, {"username": "test_user", "password": "test_password"}
+        )
+
+    @patch(
+        "scicat.SciCatAuth._get_scicat_token", return_value="test_token", autospec=True
+    )
+    def test__set_scicat_token(self, _):
+        self.scicat_auth._set_scicat_token()
+        assert scicat.Configuration.get_default().host == "http://scicat"
+        assert scicat.Configuration.get_default().access_token == "test_token"
+
+    @patch.object(scicat.SciCatAuth, "_set_scicat_token", autospec=True)
+    def test_authenticate(self, mock_set_token):
+        self.scicat_auth.authenticate()
+        mock_set_token.assert_called_once()
+
+    @patch.dict(
+        os.environ,
+        {
+            "SCICAT_ENDPOINT": "http://scicat",
+            "SCICAT_USERNAME": "test_user",
+            "SCICAT_PASSWORD": "test_password",
+        },
+    )
+    def test_from_env(self):
+        scicat_instance = scicat.SciCatAuth.from_env()
+        assert scicat_instance.__dict__ == {
+            "password": "test_password",
+            "username": "test_user",
+            "url": "http://scicat",
+        }
+
+
+class TestMarkedForDeletionJob:
+
+    def test_id(self):
+        job = scicat.MarkedForDeletionJob(FixturesJobs.raw_job())
+        assert job.id == FixturesJobs.job_id
+
+    def test_dataset_pids(self):
+        job = scicat.MarkedForDeletionJob(FixturesJobs.raw_job())
+        assert job.dataset_pids == FixturesJobs.dataset_pids
+
+    @pytest.mark.parametrize(
+        "retention_time, expected",
+        [
+            [{"value": 3, "unit": "M"}, 3],
+            [{"value": 6, "unit": "d"}, 6],
+            [{"value": 2, "unit": "h"}, 2],
+            [{"value": 10, "unit": "m"}, 10],  # lowercase m is minutes, not months
+            [{"value": 45, "unit": "s"}, 45],
+            [{"value": 1, "unit": "Y"}, 1],
+        ],
+    )
+    def test_retention_amount_reads_the_unit_from_the_object(
+        self, retention_time, expected
+    ):
+        job = scicat.MarkedForDeletionJob(
+            FixturesJobs.raw_job(job_result_object={"retentionTime": retention_time})
+        )
+        assert job.retention_amount == expected
+
+    @pytest.mark.parametrize(
+        "retention_time",
+        [
+            None,
+            {},
+            "3M",
+            {"value": 3},
+            {"unit": "M"},
+            {"value": "3", "unit": "M"},
+            {"value": 3, "unit": "X"},
+            {"value": True, "unit": "M"},
+        ],
+    )
+    def test_retention_amount_rejects_malformed_retention_time(self, retention_time):
+        job = scicat.MarkedForDeletionJob(
+            FixturesJobs.raw_job(job_result_object={"retentionTime": retention_time})
+        )
+        with pytest.raises(ValueError):
+            job.retention_amount
+
+    def test_expiry_date_uses_the_retention_time_unit(self):
+        job = scicat.MarkedForDeletionJob(
+            FixturesJobs.raw_job(
+                job_result_object={"retentionTime": {"value": 1, "unit": "Y"}}
+            )
+        )
+        assert job.expiry_date == FixturesJobs.creation_time + relativedelta(years=1)
+
+    @patch("scicat.JobsApi.jobs_controller_update_v3", autospec=True)
+    def test_advance_not_expired(self, mock_update):
+        job = scicat.MarkedForDeletionJob(
+            FixturesJobs.raw_job(
+                job_result_object={"retentionTime": {"value": 3, "unit": "M"}}
+            )
+        )
+        now = FixturesJobs.creation_time + relativedelta(months=1)
+        job.advance(now)
+        mock_update.assert_called_once_with(
+            ANY,
+            FixturesJobs.job_id,
+            {
+                "jobResultObject": {
+                    "retentionTime": {"value": 3, "unit": "M"},
+                    "lastVerifiedAt": now.isoformat(),
+                },
+            },
+        )
+
+    @patch("scicat.JobsApi.jobs_controller_update_v3", autospec=True)
+    def test_advance_expires(self, mock_update):
+        job = scicat.MarkedForDeletionJob(
+            FixturesJobs.raw_job(
+                job_result_object={"retentionTime": {"value": 3, "unit": "M"}}
+            )
+        )
+        now = FixturesJobs.creation_time + relativedelta(months=3)
+        job.advance(now)
+        mock_update.assert_called_once_with(
+            ANY,
+            FixturesJobs.job_id,
+            {
+                "jobResultObject": {
+                    "retentionTime": {"value": 3, "unit": "M"},
+                    "lastVerifiedAt": now.isoformat(),
+                },
+                "jobStatusMessage": "retentionExpired",
+            },
+        )
+
+
+class TestMarkedForDeletionJobsRepository:
+
+    @patch("scicat.JobsApi.jobs_controller_find_all_v3", autospec=True)
+    def test_due_jobs(self, mock_find_all):
+        raw_job = FixturesJobs.raw_job()
+        mock_find_all.return_value = [raw_job]
+        now = FixturesJobs.creation_time + relativedelta(months=2)
+
+        jobs = scicat.MarkedForDeletionJobsRepository().due_jobs(now)
+
+        assert len(jobs) == 1
+        assert isinstance(jobs[0], scicat.MarkedForDeletionJob)
+        assert jobs[0].id == FixturesJobs.job_id
+
+        _, kwargs = mock_find_all.call_args
+        assert json.loads(kwargs["filter"]) == {
+            "where": {
+                "type": "markedForDeletion",
+                "jobStatusMessage": {"neq": "retentionExpired"},
+                "jobResultObject.lastVerifiedAt": {
+                    "lte": (now - relativedelta(months=1)).isoformat()
+                },
+            }
+        }

--- a/retention/src/utils.py
+++ b/retention/src/utils.py
@@ -1,0 +1,4 @@
+from logging import INFO, basicConfig, getLogger
+
+basicConfig(level=INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+log = getLogger("retention")


### PR DESCRIPTION
## Workflow

1. In the frontend, a user selects datasets and clicks "mark for deletion".
   This creates a SciCat job with `type`: `markedForDeletion` and
   `datasetList`: the selected datasets.
2. A RabbitMQ listener picks up the job on creation: it patches each dataset,
   setting `datasetlifecycle.archiveStatusMessage` to `markedForDeletion`,
   and writes onto the job itself both the grace period as
   `jobResultObject.retentionTime`, e.g. `{"value": 3, "unit": "M"}` for 3
   months (`unit` follows the same calendar (uppercase `Y`/`M`) vs. clock
   (lowercase `d`/`h`/`m`/`s`) convention ISO 8601 durations use), and an
   initial `jobResultObject.lastVerifiedAt` timestamp, the baseline the first
   check-in is measured from. Until `lastVerifiedAt` is set, this service's
   query simply never selects the job — not an error, just a job the
   listener hasn't processed yet.
3. This service runs periodically (e.g. daily, via a cronjob) and fetches
   every `markedForDeletion` job whose `datasetList` isn't empty and whose
   `lastVerifiedAt` is at least one retention step old — those conditions
   are `where` clauses in the query itself, not a check done after
   fetching. For each job returned, it records the check-in as
   `jobResultObject.lastVerifiedAt` (the only kind of field the v3 API lets
   be patched after creation, alongside `jobStatusMessage`). If the job's
   full `retentionTime` grace period has elapsed since `creationTime`, its
   `jobStatusMessage` is set to `retentionExpired` — the signal for
   whichever downstream process performs the actual deletion.

Check-ins happen once every retention step (currently 1 month), independently
of `retentionTime`'s own unit — a job with `retentionTime`
`{"value": 1, "unit": "Y"}` is still re-checked monthly throughout the year,
not just once at the end. Whether the job has actually expired is a separate
check against `creationTime + retentionTime` on every check-in.

**Not yet implemented:**

- Once a job's retention period has passed, submitting a new job of type
  `delete` for its remaining datasets — with one final safety check that
  filters out any dataset whose status isn't `markedForDeletion` — instead
  of just flagging the job as `retentionExpired`.
- Paginating `due_jobs()`. The jobs endpoint caps a single response at 100
  results, so once there are more due jobs than that in one run, this
  service silently only sees the first page. It needs a `skip`/`limit`
  iterator over the loopback filter's `limits`, yielding page by page (with
  a max-iterations safety cap) until an empty page comes back.

This first version simply lets every due job run its grace period out
unconditionally.