### PR TITLE
fix: add pagination to job results

### DIFF
--- a/retention/README.md
+++ b/retention/README.md
@@ -21,12 +21,15 @@
    every `markedForDeletion` job whose `datasetList` isn't empty and whose
    `lastVerifiedAt` is at least one retention step old — those conditions
    are `where` clauses in the query itself, not a check done after
-   fetching. For each job returned, it records the check-in as
-   `jobResultObject.lastVerifiedAt` (the only kind of field the v3 API lets
-   be patched after creation, alongside `jobStatusMessage`). If the job's
-   full `retentionTime` grace period has elapsed since `creationTime`, its
-   `jobStatusMessage` is set to `retentionExpired` — the signal for
-   whichever downstream process performs the actual deletion.
+   fetching. The query is paginated 100 jobs at a time (`limits.skip`/
+   `limits.limit`), walking pages until an empty one comes back, with a
+   safety cap on the number of pages fetched in one run. For each job
+   returned, it records the check-in as `jobResultObject.lastVerifiedAt`
+   (the only kind of field the v3 API lets be patched after creation,
+   alongside `jobStatusMessage`). If the job's full `retentionTime` grace
+   period has elapsed since `creationTime`, its `jobStatusMessage` is set
+   to `retentionExpired` — the signal for whichever downstream process
+   performs the actual deletion.
 
 Check-ins happen once every retention step (currently 1 month), independently
 of `retentionTime`'s own unit — a job with `retentionTime`
@@ -40,11 +43,6 @@ check against `creationTime + retentionTime` on every check-in.
   `delete` for its remaining datasets — with one final safety check that
   filters out any dataset whose status isn't `markedForDeletion` — instead
   of just flagging the job as `retentionExpired`.
-- Paginating `due_jobs()`. The jobs endpoint caps a single response at 100
-  results, so once there are more due jobs than that in one run, this
-  service silently only sees the first page. It needs a `skip`/`limit`
-  iterator over the loopback filter's `limits`, yielding page by page (with
-  a max-iterations safety cap) until an empty page comes back.
 
 This first version simply lets every due job run its grace period out
 unconditionally.

--- a/retention/README.md
+++ b/retention/README.md
@@ -21,9 +21,11 @@
    every `markedForDeletion` job whose `datasetList` isn't empty and whose
    `lastVerifiedAt` is at least one retention step old — those conditions
    are `where` clauses in the query itself, not a check done after
-   fetching. The query is paginated 100 jobs at a time (`limits.skip`/
-   `limits.limit`), walking pages until an empty one comes back, with a
-   safety cap on the number of pages fetched in one run. For each job
+   fetching, and only the fields this service actually reads (`id`,
+   `datasetList`, `jobResultObject`, `creationTime`) are requested. The
+   query is paginated 100 jobs at a time (`limits.skip`/`limits.limit`),
+   walking pages until an empty one comes back, with a safety cap on the
+   number of pages fetched in one run. For each job
    returned, it records the check-in as `jobResultObject.lastVerifiedAt`
    (the only kind of field the v3 API lets be patched after creation,
    alongside `jobStatusMessage`). If the job's full `retentionTime` grace

--- a/retention/src/orchestrator.py
+++ b/retention/src/orchestrator.py
@@ -22,11 +22,12 @@ class RetentionOrchestrator:
         log.info(f"Connecting to scicat on {self.scicat_instance.url}")
         self.scicat_instance.authenticate()
         now = datetime.now(timezone.utc)
-        due_jobs = self.jobs.due_jobs(now)
-        log.info(f"{len(due_jobs)} job(s) due for a check-in")
-        for job in due_jobs:
+        processed = 0
+        for job in self.jobs.due_jobs(now):
+            processed += 1
             try:
                 job.advance(now)
             except Exception as e:
                 log.error(f"Failed to process job {job.id}: {e}")
+        log.info(f"{processed} job(s) due for a check-in")
         log.info("==== Retention check finished ====")

--- a/retention/src/scicat.py
+++ b/retention/src/scicat.py
@@ -151,6 +151,9 @@ class MarkedForDeletionJob:
 class MarkedForDeletionJobsRepository:
     """Fetches SciCat "markedForDeletion" jobs whose next check-in is due."""
 
+    page_limit = 100
+    max_iterations = 1000
+
     @staticmethod
     def _due_jobs_filter(now):
         # lastVerifiedAt is written by the marking agent at job creation (as
@@ -167,10 +170,23 @@ class MarkedForDeletionJobsRepository:
             }
         }
 
-    def due_jobs(self, now):
-        """Returns markedForDeletion jobs due for a check-in, as MarkedForDeletionJob."""
-        log.info("Fetching markedForDeletion jobs due for a check-in")
-        jobs = JobsApi().jobs_controller_find_all_v3(
-            filter=json.dumps(self._due_jobs_filter(now))
+    def _due_jobs_batches(self, now):
+        """Yields pages of due jobs, walking `limits.skip` until a page is empty."""
+        filter_ = self._due_jobs_filter(now)
+        filter_["limits"] = {"skip": 0, "limit": self.page_limit}
+        for _ in range(self.max_iterations):
+            batch = JobsApi().jobs_controller_find_all_v3(filter=json.dumps(filter_))
+            if not batch:
+                return
+            yield batch
+            filter_["limits"]["skip"] += self.page_limit
+        raise RuntimeError(
+            "Exceeded maximum pages while fetching due markedForDeletion jobs"
         )
-        return [MarkedForDeletionJob(job) for job in jobs]
+
+    def due_jobs(self, now):
+        """Yields markedForDeletion jobs due for a check-in, as MarkedForDeletionJob."""
+        log.info("Fetching markedForDeletion jobs due for a check-in")
+        for batch in self._due_jobs_batches(now):
+            for job in batch:
+                yield MarkedForDeletionJob(job)

--- a/retention/src/scicat.py
+++ b/retention/src/scicat.py
@@ -154,8 +154,9 @@ class MarkedForDeletionJobsRepository:
     page_limit = 100
     max_iterations = 1000
 
-    @staticmethod
-    def _due_jobs_filter(now):
+    fields = ["id", "datasetList", "jobResultObject", "creationTime"]
+
+    def _due_jobs_filter(self, now):
         # lastVerifiedAt is written by the marking agent at job creation (as
         # well as by this service on every check-in), so a due job is simply
         # one whose last check-in is at least one retention step old.
@@ -167,7 +168,8 @@ class MarkedForDeletionJobsRepository:
                 f"jobResultObject.{RESULT_LAST_VERIFIED_AT}": {
                     "lte": (now - _RETENTION_STEP_DELTA).isoformat()
                 },
-            }
+            },
+            "fields": self.fields,
         }
 
     def _due_jobs_batches(self, now):

--- a/retention/src/tests/test_scicat.py
+++ b/retention/src/tests/test_scicat.py
@@ -184,6 +184,7 @@ class TestMarkedForDeletionJobsRepository:
                     "lte": (now - relativedelta(months=1)).isoformat()
                 },
             },
+            "fields": ["id", "datasetList", "jobResultObject", "creationTime"],
             "limits": {"skip": 0, "limit": 100},
         }
 

--- a/retention/src/tests/test_scicat.py
+++ b/retention/src/tests/test_scicat.py
@@ -165,16 +165,16 @@ class TestMarkedForDeletionJobsRepository:
     @patch("scicat.JobsApi.jobs_controller_find_all_v3", autospec=True)
     def test_due_jobs(self, mock_find_all):
         raw_job = FixturesJobs.raw_job()
-        mock_find_all.return_value = [raw_job]
+        mock_find_all.side_effect = [[raw_job], []]
         now = FixturesJobs.creation_time + relativedelta(months=2)
 
-        jobs = scicat.MarkedForDeletionJobsRepository().due_jobs(now)
+        jobs = list(scicat.MarkedForDeletionJobsRepository().due_jobs(now))
 
         assert len(jobs) == 1
         assert isinstance(jobs[0], scicat.MarkedForDeletionJob)
         assert jobs[0].id == FixturesJobs.job_id
 
-        _, kwargs = mock_find_all.call_args
+        _, kwargs = mock_find_all.call_args_list[0]
         assert json.loads(kwargs["filter"]) == {
             "where": {
                 "type": "markedForDeletion",
@@ -183,5 +183,61 @@ class TestMarkedForDeletionJobsRepository:
                 "jobResultObject.lastVerifiedAt": {
                     "lte": (now - relativedelta(months=1)).isoformat()
                 },
-            }
+            },
+            "limits": {"skip": 0, "limit": 100},
         }
+
+    @patch("scicat.JobsApi.jobs_controller_find_all_v3", autospec=True)
+    def test_due_jobs_paginates_across_multiple_pages(self, mock_find_all):
+        page1 = [
+            FixturesJobs.raw_job(job_id="job1"),
+            FixturesJobs.raw_job(job_id="job2"),
+        ]
+        page2 = [FixturesJobs.raw_job(job_id="job3")]
+        mock_find_all.side_effect = [page1, page2, []]
+        now = FixturesJobs.creation_time + relativedelta(months=2)
+
+        repository = scicat.MarkedForDeletionJobsRepository()
+        repository.page_limit = 2
+        jobs = repository.due_jobs(now)
+
+        assert [job.id for job in jobs] == ["job1", "job2", "job3"]
+        assert mock_find_all.call_count == 3
+        skips = [
+            json.loads(kwargs["filter"])["limits"]["skip"]
+            for _, kwargs in mock_find_all.call_args_list
+        ]
+        assert skips == [0, 2, 4]
+
+    @patch("scicat.JobsApi.jobs_controller_find_all_v3", autospec=True)
+    def test_due_jobs_fetches_pages_lazily(self, mock_find_all):
+        page1 = [
+            FixturesJobs.raw_job(job_id="job1"),
+            FixturesJobs.raw_job(job_id="job2"),
+        ]
+        page2 = [FixturesJobs.raw_job(job_id="job3")]
+        mock_find_all.side_effect = [page1, page2, []]
+        now = FixturesJobs.creation_time + relativedelta(months=2)
+
+        repository = scicat.MarkedForDeletionJobsRepository()
+        repository.page_limit = 2
+        jobs = repository.due_jobs(now)
+
+        assert next(jobs).id == "job1"
+        assert mock_find_all.call_count == 1
+        assert next(jobs).id == "job2"
+        assert mock_find_all.call_count == 1
+        assert next(jobs).id == "job3"
+        assert mock_find_all.call_count == 2
+
+    @patch("scicat.JobsApi.jobs_controller_find_all_v3", autospec=True)
+    def test_due_jobs_raises_after_max_iterations(self, mock_find_all):
+        mock_find_all.return_value = [FixturesJobs.raw_job()]
+        now = FixturesJobs.creation_time + relativedelta(months=2)
+
+        repository = scicat.MarkedForDeletionJobsRepository()
+        repository.max_iterations = 3
+
+        with pytest.raises(RuntimeError):
+            list(repository.due_jobs(now))
+        assert mock_find_all.call_count == 3


### PR DESCRIPTION
Since the be limits results to be at most 100 from a single query, this PR adds iterating on the pages and yields results to free up memory